### PR TITLE
feat: add Prometheus + Grafana monitoring stack (closes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ The server listens on `http://localhost:8080` by default.
 |---|---|---|
 | `PORT` | `8080` | Port the HTTP server listens on |
 | `API_KEY` | *(unset)* | If set, all POST requests must include `Authorization: Bearer <key>` or `Authorization: Api-Key <key>`. Leave empty to disable auth. |
+| `GATEWAY_METRICS_PORT` | `9101` | Port for the Prometheus metrics scrape endpoint |
+| `GPU_HOURLY_COST_USD` | `1.10` | Hourly GPU cost used to estimate `gateway_gpu_cost_usd_total` (A10 default) |
+| `VLLM_SERVER_PROFILE` | `default` | Server profile label attached to all Prometheus metrics (e.g. `chunked_prefill`, `baseline`) |
 
 ### Backend configuration (`config.yaml`)
 
@@ -45,23 +48,20 @@ Backends are configured in `config.yaml`. The gateway routes requests by matchin
 
 ```yaml
 backends:
-  - name: local          # echo mode — no real backend needed
+  - name: local                  # echo mode — no real backend needed
     type: echo
 
-  - name: local-llama    # local llama.cpp server
+  - name: modal-gemma4-standard  # vLLM Gemma4 standard on Modal
     type: http
-    url: http://localhost:8081
-    timeout: 60
-
-  - name: remote-modal-llama   # llama.cpp hosted on Modal
-    type: http
-    url: https://ingo-villnow--relay-llama-server-web.modal.run/
-    timeout: 60
-
-  - name: remote-modal-vllm   # vLLM hosted on Modal
-    type: http
-    url: https://ingo-villnow--relay-vllm-server-web.modal.run/
+    url: https://ingo-villnow--vllm-gemma4-standard-serve.modal.run/
     timeout: 120
+    model: gemma-4-e2b-it        # vLLM requires this field
+
+  - name: modal-gemma4-optimized # vLLM Gemma4 optimized on Modal
+    type: http
+    url: https://ingo-villnow--vllm-gemma4-optimized-serve.modal.run/
+    timeout: 120
+    model: gemma-4-e2b-it
 
 default_backend: local
 ```
@@ -79,7 +79,8 @@ default_backend: local
 | `POST` | `/v1/chat/completions` | Main inference endpoint |
 | `GET` | `/v1/backends` | List configured backends and default |
 | `GET` | `/healthz` | Health check |
-| `GET` | `/metrics` | Request/latency/token counters |
+| `GET` | `/metrics` | Legacy JSON counters (request count, latency, tokens) |
+| `GET` | `:9101/metrics` | Prometheus-format metrics (dedicated scrape port) |
 
 ### Request body (`POST /v1/chat/completions`)
 
@@ -121,20 +122,20 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 
 Response includes `"backend": "local"` and content `"Echo: hello"`.
 
-### Route to remote llama.cpp on Modal
+### Route to Modal vLLM (standard)
 
 ```bash
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -d '{"model": "remote-modal-llama", "messages": [{"role": "user", "content": "say hi"}], "max_tokens": 50}'
+  -d '{"model": "modal-gemma4-standard", "messages": [{"role": "user", "content": "say hi"}], "max_tokens": 50}'
 ```
 
-### Route to remote vLLM on Modal
+### Route to Modal vLLM (optimized)
 
 ```bash
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -d '{"model": "remote-modal-vllm", "messages": [{"role": "user", "content": "say hi"}], "max_tokens": 50}'
+  -d '{"model": "modal-gemma4-optimized", "messages": [{"role": "user", "content": "say hi"}], "max_tokens": 50}'
 ```
 
 ### Omit model — falls back to default backend
@@ -179,8 +180,23 @@ curl http://localhost:8080/healthz
 ### Metrics
 
 ```bash
+# Legacy JSON counters
 curl http://localhost:8080/metrics
-# → {"request_count": N, "error_count": N, "total_latency_ms": N, ...}
+# → {"request_count": N, "error_count": N, "avg_latency_ms": N, ...}
+
+# Prometheus scrape endpoint (separate port)
+curl http://localhost:9101/metrics
+# → # HELP gateway_requests_total ...
+#   gateway_requests_total{status_code="200",model="local",technique="baseline",...} 5.0
+```
+
+Pass `X-Technique` on requests to segment metrics by inference technique (e.g. `chunked_prefill`, `prefix_caching`). Missing header defaults to `baseline`.
+
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -H 'X-Technique: chunked_prefill' \
+  -d '{"model": "local", "messages": [{"role": "user", "content": "hello"}]}'
 ```
 
 ---
@@ -196,7 +212,7 @@ uv run pytest tests/test_gateway.py::test_routing_by_model_echo   # single test
 
 The suite starts real `HTTPServer` instances on free ports and uses [respx](https://lundberg.github.io/respx/) to mock backend `httpx` calls. No running backend is required.
 
-**51 tests** covering: GET endpoints, echo shape, request-ID, validation errors (400), auth (401), SSE streaming, backend proxy, response normalization, multi-backend routing, metrics, `latency_ms` in usage.
+**60 tests** covering: GET endpoints, echo shape, request-ID, validation errors (400), auth (401), SSE streaming, backend proxy, response normalization, multi-backend routing, metrics, `latency_ms` in usage, Prometheus counter/histogram/gauge behaviour, `X-Technique` label propagation.
 
 ### Live backend tests
 
@@ -214,7 +230,38 @@ Live tests skip gracefully (rather than fail) when a backend returns 502/504.
 
 ### Bruno collection
 
-Open `tests/bruno/` in [Bruno](https://www.usebruno.com/) and select the **local** environment (`base_url = http://localhost:8080`).
+Open `tests/bruno/` in [Bruno](https://www.usebruno.com/) and select the **local** environment (`base_url = http://localhost:8080`, `metrics_url = http://localhost:9101`).
+
+---
+
+## Monitoring Stack (Prometheus + Grafana)
+
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) with Compose
+
+```bash
+# 1. Start the gateway first
+uv run python main.py
+
+# 2. Launch Prometheus + Grafana
+cd monitoring
+docker compose up -d
+```
+
+| Service | URL | Credentials |
+|---|---|---|
+| Prometheus | http://localhost:9090 | — |
+| Grafana | http://localhost:3000 | admin / admin |
+
+Prometheus scrapes:
+- Gateway metrics on `:9101` (`job_name: gateway`)
+- Modal vLLM standard deployment over HTTPS (`job_name: vllm_standard`)
+- Modal vLLM optimized deployment over HTTPS (`job_name: vllm_optimized`)
+
+Set `VLLM_SERVER_PROFILE=default` or `VLLM_SERVER_PROFILE=optimized` in `.env` to label gateway metrics with the active deployment.
+
+Check targets are **UP**: http://localhost:9090/targets
+
+Grafana loads with a pre-provisioned Prometheus datasource and four dashboards: **gateway-proxy**, **overview**, **technique-cost**, **tinyllama-ops**.
 
 ---
 

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,30 @@
+# Run from this directory:  docker compose up -d
+# Prometheus scrapes the gateway (:9101) and vLLM (:8000) on your host via host.docker.internal
+# (Linux: extra_hosts below maps host.docker.internal → host gateway).
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --web.enable-lifecycle
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana_dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yaml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+providers:
+  - name: TinyLlama
+    orgId: 1
+    folder: TinyLlama
+    type: file
+    disableDeletion: false
+    editable: true
+    # Reload JSON from disk periodically (dashboard Refresh only re-queries Prometheus).
+    updateIntervalSeconds: 5
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/datasources.yaml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    uid: prometheus
+    editable: false

--- a/monitoring/grafana_dashboards/gateway-proxy.json
+++ b/monitoring/grafana_dashboards/gateway-proxy.json
@@ -1,0 +1,194 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 5, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "content": "## Gateway proxy metrics (laptop)\n\nThese come from **`python gateway.py`** on **`:9101/metrics`**. They measure **HTTP proxy + tunnel** behavior, not raw vLLM internals. **TTFT** = first upstream byte (streaming) or full response time (non-stream). **TPOT** = mean inter-chunk delay (streaming) or `e2e / completion_tokens` (non-stream). Compare with the **vLLM — prefill vs decode** dashboard for engine-native histograms (`vllm_*` names vary by vLLM version).\n\n**Streaming inter-chunk** panels stay **empty** until at least one **`Accept: text/event-stream`** completion runs through the gateway (Crew/litellm default is non-streaming).\n\n**Labels:** `technique` = `X-Technique` header or `crew.py --technique`. `server_profile` = `VLLM_SERVER_PROFILE` in `.env` (which server config you believe is live). For fair A/B tests, change **vLLM flags** on the GPU, set **`VLLM_SERVER_PROFILE`** to match, restart the gateway, then run Crew.",
+        "mode": "markdown"
+      },
+      "title": "How to read this board",
+      "type": "text"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "`llm_gateway_info` is a 1.0 gauge with labels (extended_timing, schema). Table + instant query is easier than Stat.",
+      "fieldConfig": {"defaults": {"custom": {"align": "auto", "inspect": false}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 8, "x": 0, "y": 5},
+      "id": 2,
+      "options": {"cellHeight": "sm", "footer": {"countRows": false, "fields": "", "reducer": ["sum"], "show": false}, "showHeader": true, "sortBy": []},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "llm_gateway_info",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway build info (llm_gateway_info)",
+      "type": "table"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 8, "x": 8, "y": 5},
+      "id": 3,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "expr": "sum by (technique, server_profile) (rate(llm_gateway_requests_total[5m]))",
+          "legendFormat": "{{technique}} / {{server_profile}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request rate (completed proxy calls)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 9},
+      "id": 4,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(llm_gateway_time_to_first_token_seconds_bucket[5m])))",
+          "legendFormat": "p95 TTFT {{technique}}/{{server_profile}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, technique, server_profile) (rate(llm_gateway_time_to_first_token_seconds_bucket[5m])))",
+          "legendFormat": "p50 TTFT {{technique}}/{{server_profile}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Time to first token (gateway proxy)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 9},
+      "id": 5,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(llm_gateway_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 E2E {{technique}}/{{server_profile}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, technique, server_profile) (rate(llm_gateway_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50 E2E {{technique}}/{{server_profile}}",
+          "refId": "B"
+        }
+      ],
+      "title": "End-to-end request duration (gateway)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 17},
+      "id": 6,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(llm_gateway_time_per_output_token_seconds_bucket[5m])))",
+          "legendFormat": "p95 TPOT {{technique}}/{{server_profile}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, technique, server_profile) (rate(llm_gateway_time_per_output_token_seconds_bucket[5m])))",
+          "legendFormat": "p50 TPOT {{technique}}/{{server_profile}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Time per output token (proxy estimate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "Histogram exists only after streaming requests. Non-streaming Crew/curl traffic leaves this empty. Second series shows observation rate (still 0 until streaming).",
+      "fieldConfig": {
+        "defaults": {"noValue": "No streaming yet", "unit": "s"},
+        "overrides": [{"matcher": {"id": "byName", "options": "observations/s (all techniques)"}, "properties": [{"id": "unit", "value": "ops"}, {"id": "custom.axisPlacement", "value": "right"}]}]
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 17},
+      "id": 7,
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(llm_gateway_stream_inter_chunk_delay_seconds_bucket[5m])))",
+          "legendFormat": "p95 inter-chunk {{technique}}/{{server_profile}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "sum(rate(llm_gateway_stream_inter_chunk_delay_seconds_count[5m]))",
+          "legendFormat": "observations/s (all techniques)",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Streaming inter-chunk delay (SSE only)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "tps"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 25},
+      "id": 8,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, technique, server_profile) (rate(llm_gateway_completion_tokens_per_second_bucket[5m])))",
+          "legendFormat": "p50 tok/s {{technique}}/{{server_profile}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(llm_gateway_completion_tokens_per_second_bucket[5m])))",
+          "legendFormat": "p95 tok/s {{technique}}/{{server_profile}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Completion tokens per second (from usage / e2e)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "currencyUSD"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 25},
+      "id": 9,
+      "targets": [
+        {
+          "expr": "sum by (technique, server_profile) (rate(llm_gateway_estimated_gpu_cost_usd_total[5m]))",
+          "legendFormat": "$/s {{technique}}/{{server_profile}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Estimated GPU spend rate (gateway cost model)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["gateway", "ttft", "tpot"],
+  "templating": {"list": []},
+  "time": {"from": "now-1h", "to": "now"},
+  "timezone": "browser",
+  "title": "Gateway — proxy timings + cost",
+  "uid": "tt-gateway-proxy",
+  "version": 5
+}

--- a/monitoring/grafana_dashboards/gateway-proxy.json
+++ b/monitoring/grafana_dashboards/gateway-proxy.json
@@ -1,5 +1,7 @@
 {
-  "annotations": {"list": []},
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -7,48 +9,51 @@
   "links": [],
   "panels": [
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "gridPos": {"h": 5, "w": 24, "x": 0, "y": 0},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "options": {
-        "content": "## Gateway proxy metrics (laptop)\n\nThese come from **`python gateway.py`** on **`:9101/metrics`**. They measure **HTTP proxy + tunnel** behavior, not raw vLLM internals. **TTFT** = first upstream byte (streaming) or full response time (non-stream). **TPOT** = mean inter-chunk delay (streaming) or `e2e / completion_tokens` (non-stream). Compare with the **vLLM — prefill vs decode** dashboard for engine-native histograms (`vllm_*` names vary by vLLM version).\n\n**Streaming inter-chunk** panels stay **empty** until at least one **`Accept: text/event-stream`** completion runs through the gateway (Crew/litellm default is non-streaming).\n\n**Labels:** `technique` = `X-Technique` header or `crew.py --technique`. `server_profile` = `VLLM_SERVER_PROFILE` in `.env` (which server config you believe is live). For fair A/B tests, change **vLLM flags** on the GPU, set **`VLLM_SERVER_PROFILE`** to match, restart the gateway, then run Crew.",
+        "content": "## Gateway proxy metrics (laptop)\n\nThese come from **`python gateway.py`** on **`:9101/metrics`**. They measure **HTTP proxy + tunnel** behavior, not raw vLLM internals. **TTFT** = first upstream byte (streaming) or full response time (non-stream). **TPOT** = mean inter-chunk delay (streaming) or `e2e / completion_tokens` (non-stream). Compare with the **vLLM \u2014 prefill vs decode** dashboard for engine-native histograms (`vllm_*` names vary by vLLM version).\n\n**Streaming inter-chunk** panels stay **empty** until at least one **`Accept: text/event-stream`** completion runs through the gateway (Crew/litellm default is non-streaming).\n\n**Labels:** `technique` = `X-Technique` header or `crew.py --technique`. `server_profile` = `VLLM_SERVER_PROFILE` in `.env` (which server config you believe is live). For fair A/B tests, change **vLLM flags** on the GPU, set **`VLLM_SERVER_PROFILE`** to match, restart the gateway, then run Crew.",
         "mode": "markdown"
       },
       "title": "How to read this board",
       "type": "text"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "description": "`llm_gateway_info` is a 1.0 gauge with labels (extended_timing, schema). Table + instant query is easier than Stat.",
-      "fieldConfig": {"defaults": {"custom": {"align": "auto", "inspect": false}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}}, "overrides": []},
-      "gridPos": {"h": 4, "w": 8, "x": 0, "y": 5},
-      "id": 2,
-      "options": {"cellHeight": "sm", "footer": {"countRows": false, "fields": "", "reducer": ["sum"], "show": false}, "showHeader": true, "sortBy": []},
-      "targets": [
-        {
-          "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "llm_gateway_info",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Gateway build info (llm_gateway_info)",
-      "type": "table"
-    },
-    {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
-      "gridPos": {"h": 4, "w": 8, "x": 8, "y": 5},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 5
+      },
       "id": 3,
-      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
       "targets": [
         {
-          "expr": "sum by (technique, server_profile) (rate(llm_gateway_requests_total[5m]))",
+          "expr": "sum by (technique, server_profile) (rate(gateway_requests_total[5m]))",
           "legendFormat": "{{technique}} / {{server_profile}}",
           "refId": "A"
         }
@@ -57,18 +62,31 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 9},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
       "id": 4,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(llm_gateway_time_to_first_token_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(gateway_ttft_seconds_bucket[5m])))",
           "legendFormat": "p95 TTFT {{technique}}/{{server_profile}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum by (le, technique, server_profile) (rate(llm_gateway_time_to_first_token_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le, technique, server_profile) (rate(gateway_ttft_seconds_bucket[5m])))",
           "legendFormat": "p50 TTFT {{technique}}/{{server_profile}}",
           "refId": "B"
         }
@@ -77,18 +95,31 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 9},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
       "id": 5,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(llm_gateway_request_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(gateway_request_duration_seconds_bucket[5m])))",
           "legendFormat": "p95 E2E {{technique}}/{{server_profile}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum by (le, technique, server_profile) (rate(llm_gateway_request_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le, technique, server_profile) (rate(gateway_request_duration_seconds_bucket[5m])))",
           "legendFormat": "p50 E2E {{technique}}/{{server_profile}}",
           "refId": "B"
         }
@@ -97,47 +128,61 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 17},
-      "id": 6,
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(llm_gateway_time_per_output_token_seconds_bucket[5m])))",
-          "legendFormat": "p95 TPOT {{technique}}/{{server_profile}}",
-          "refId": "A"
-        },
-        {
-          "expr": "histogram_quantile(0.50, sum by (le, technique, server_profile) (rate(llm_gateway_time_per_output_token_seconds_bucket[5m])))",
-          "legendFormat": "p50 TPOT {{technique}}/{{server_profile}}",
-          "refId": "B"
-        }
-      ],
-      "title": "Time per output token (proxy estimate)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Histogram exists only after streaming requests. Non-streaming Crew/curl traffic leaves this empty. Second series shows observation rate (still 0 until streaming).",
       "fieldConfig": {
-        "defaults": {"noValue": "No streaming yet", "unit": "s"},
-        "overrides": [{"matcher": {"id": "byName", "options": "observations/s (all techniques)"}, "properties": [{"id": "unit", "value": "ops"}, {"id": "custom.axisPlacement", "value": "right"}]}]
+        "defaults": {
+          "noValue": "No streaming yet",
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "observations/s (all techniques)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ops"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 17},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
       "id": 7,
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(llm_gateway_stream_inter_chunk_delay_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(gateway_inter_chunk_seconds_bucket[5m])))",
           "legendFormat": "p95 inter-chunk {{technique}}/{{server_profile}}",
           "range": true,
           "refId": "A"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
-          "expr": "sum(rate(llm_gateway_stream_inter_chunk_delay_seconds_count[5m]))",
+          "expr": "sum(rate(gateway_inter_chunk_seconds_count[5m]))",
           "legendFormat": "observations/s (all techniques)",
           "range": true,
           "refId": "B"
@@ -147,33 +192,26 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "tps"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 25},
-      "id": 8,
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.50, sum by (le, technique, server_profile) (rate(llm_gateway_completion_tokens_per_second_bucket[5m])))",
-          "legendFormat": "p50 tok/s {{technique}}/{{server_profile}}",
-          "refId": "A"
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD"
         },
-        {
-          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(llm_gateway_completion_tokens_per_second_bucket[5m])))",
-          "legendFormat": "p95 tok/s {{technique}}/{{server_profile}}",
-          "refId": "B"
-        }
-      ],
-      "title": "Completion tokens per second (from usage / e2e)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "currencyUSD"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 25},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
       "id": 9,
       "targets": [
         {
-          "expr": "sum by (technique, server_profile) (rate(llm_gateway_estimated_gpu_cost_usd_total[5m]))",
+          "expr": "sum by (technique, server_profile) (rate(gateway_gpu_cost_usd_total[5m]))",
           "legendFormat": "$/s {{technique}}/{{server_profile}}",
           "refId": "A"
         }
@@ -184,11 +222,20 @@
   ],
   "refresh": "10s",
   "schemaVersion": 39,
-  "tags": ["gateway", "ttft", "tpot"],
-  "templating": {"list": []},
-  "time": {"from": "now-1h", "to": "now"},
+  "tags": [
+    "gateway",
+    "ttft",
+    "tpot"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "timezone": "browser",
-  "title": "Gateway — proxy timings + cost",
+  "title": "Gateway \u2014 proxy timings + cost",
   "uid": "tt-gateway-proxy",
   "version": 5
 }

--- a/monitoring/grafana_dashboards/overview.json
+++ b/monitoring/grafana_dashboards/overview.json
@@ -1,0 +1,155 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 7, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"content": "## vLLM overview (engine-native metrics)\n\n**vLLM 0.13+** exposes OpenMetrics-style names with a **`vllm:`** prefix (e.g. `vllm:request_prefill_time_seconds_bucket`), scraped from **`:8000/metrics`**. Older builds used **`vllm_`** underscores — adjust in **Explore** if needed.\n\n**Decode panel** uses **`vllm:inter_token_latency_seconds`** (per autoregressive step); there is no separate `request_decode` histogram in current vLLM exports.\n\n**Speculative decode panel (below):** shows **`vllm:spec_decode_*`** from the **vLLM process only**. It is **not** tied to Crew/gateway **`--technique speculative_decoding`** or **`combined`** — those names are just **`X-Technique`** labels on gateway logs and `llm_gateway_*`. If this panel is empty, vLLM was almost certainly **not** launched with speculative decoding enabled (no draft model / spec flags), so the engine never exports these series. Confirm with `curl -sS :8000/metrics | grep -i spec_decode` on the tunnel.\n\n**Gateway** metrics (`llm_gateway_*`): dashboard **Gateway — proxy timings + cost** (per-technique request rates, latency, cost).\n\n**Jaeger:** **`X-Trace-Id`**.", "mode": "markdown"},
+      "title": "Notes",
+      "type": "text"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 7},
+      "id": 2,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:request_prefill_time_seconds_bucket[5m])))",
+          "legendFormat": "p95 prefill",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(vllm:request_prefill_time_seconds_bucket[5m])))",
+          "legendFormat": "p50 prefill",
+          "refId": "B"
+        }
+      ],
+      "title": "Prefill latency (vllm:request_prefill_time_seconds)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 7},
+      "id": 3,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:inter_token_latency_seconds_bucket[5m])))",
+          "legendFormat": "p95 inter-token",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(vllm:inter_token_latency_seconds_bucket[5m])))",
+          "legendFormat": "p50 inter-token",
+          "refId": "B"
+        }
+      ],
+      "title": "Inter-token latency (decode steps, vllm:inter_token_latency_seconds)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 15},
+      "id": 4,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:time_to_first_token_seconds_bucket[5m])))",
+          "legendFormat": "p95 TTFT",
+          "refId": "A"
+        }
+      ],
+      "title": "TTFT (vllm:time_to_first_token_seconds)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "tps"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 15},
+      "id": 5,
+      "targets": [
+        {
+          "expr": "sum(rate(vllm:generation_tokens_total[1m]))",
+          "legendFormat": "gen tokens/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Generation throughput (tokens/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "percentunit"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 23},
+      "id": 6,
+      "targets": [
+        {
+          "expr": "vllm:kv_cache_usage_perc",
+          "legendFormat": "KV cache %",
+          "refId": "A"
+        }
+      ],
+      "title": "KV cache usage (vllm:kv_cache_usage_perc)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "Engine metrics from vLLM :8000/metrics — not from gateway X-Technique. Empty if vLLM was not started with speculative decoding (draft/spec flags). Crew labels like speculative_decoding or combined only tag llm_gateway_* / JSONL; they do not turn this on.",
+      "fieldConfig": {"defaults": {"unit": "percentunit", "min": 0, "max": 1}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 23},
+      "id": 7,
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "vllm:spec_decode_draft_acceptance_rate",
+          "legendFormat": "draft_acceptance_rate (gauge, vllm:)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "sum(rate(vllm:spec_decode_num_accepted_tokens_total[5m])) / sum(rate(vllm:spec_decode_num_draft_tokens_total[5m]))",
+          "legendFormat": "accepted/draft (counters, vllm:)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "vllm_spec_decode_draft_acceptance_rate",
+          "legendFormat": "draft_acceptance_rate (legacy vllm_)",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "sum(rate(vllm_spec_decode_num_accepted_tokens_total[5m])) / sum(rate(vllm_spec_decode_num_draft_tokens_total[5m]))",
+          "legendFormat": "accepted/draft (legacy vllm_)",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Speculative decode (if enabled)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["vllm", "texttinyllama"],
+  "templating": {"list": []},
+  "time": {"from": "now-1h", "to": "now"},
+  "timezone": "browser",
+  "title": "vLLM — prefill vs decode",
+  "uid": "tt-vllm-overview",
+  "version": 7
+}

--- a/monitoring/grafana_dashboards/overview.json
+++ b/monitoring/grafana_dashboards/overview.json
@@ -1,5 +1,7 @@
 {
-  "annotations": {"list": []},
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -7,17 +9,41 @@
   "links": [],
   "panels": [
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "gridPos": {"h": 7, "w": 24, "x": 0, "y": 0},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
-      "options": {"content": "## vLLM overview (engine-native metrics)\n\n**vLLM 0.13+** exposes OpenMetrics-style names with a **`vllm:`** prefix (e.g. `vllm:request_prefill_time_seconds_bucket`), scraped from **`:8000/metrics`**. Older builds used **`vllm_`** underscores — adjust in **Explore** if needed.\n\n**Decode panel** uses **`vllm:inter_token_latency_seconds`** (per autoregressive step); there is no separate `request_decode` histogram in current vLLM exports.\n\n**Speculative decode panel (below):** shows **`vllm:spec_decode_*`** from the **vLLM process only**. It is **not** tied to Crew/gateway **`--technique speculative_decoding`** or **`combined`** — those names are just **`X-Technique`** labels on gateway logs and `llm_gateway_*`. If this panel is empty, vLLM was almost certainly **not** launched with speculative decoding enabled (no draft model / spec flags), so the engine never exports these series. Confirm with `curl -sS :8000/metrics | grep -i spec_decode` on the tunnel.\n\n**Gateway** metrics (`llm_gateway_*`): dashboard **Gateway — proxy timings + cost** (per-technique request rates, latency, cost).\n\n**Jaeger:** **`X-Trace-Id`**.", "mode": "markdown"},
+      "options": {
+        "content": "## vLLM overview (engine-native metrics)\n\n**vLLM 0.13+** exposes OpenMetrics-style names with a **`vllm:`** prefix (e.g. `vllm:request_prefill_time_seconds_bucket`), scraped from **`Modal /metrics (HTTPS)`**. Older builds used **`vllm_`** underscores \u2014 adjust in **Explore** if needed.\n\n**Decode panel** uses **`vllm:inter_token_latency_seconds`** (per autoregressive step); there is no separate `request_decode` histogram in current vLLM exports.\n\n**Speculative decode panel (below):** shows **`vllm:spec_decode_*`** from the **vLLM process only**. It is **not** tied to Crew/gateway **`--technique speculative_decoding`** or **`combined`** \u2014 those names are just **`X-Technique`** labels on gateway logs and `gateway_*`. If this panel is empty, vLLM was almost certainly **not** launched with speculative decoding enabled (no draft model / spec flags), so the engine never exports these series. Confirm with `curl -sS Modal /metrics (HTTPS) | grep -i spec_decode` on the tunnel.\n\n**Gateway** metrics (`gateway_*`): dashboard **Gateway \u2014 proxy timings + cost** (per-technique request rates, latency, cost).\n\n**Jaeger:** **`X-Trace-Id`**.",
+        "mode": "markdown"
+      },
       "title": "Notes",
       "type": "text"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 7},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
       "id": 2,
       "targets": [
         {
@@ -35,9 +61,22 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 7},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
       "id": 3,
       "targets": [
         {
@@ -55,9 +94,22 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 15},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
       "id": 4,
       "targets": [
         {
@@ -70,9 +122,22 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "tps"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 15},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "tps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
       "id": 5,
       "targets": [
         {
@@ -85,9 +150,22 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "percentunit"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 23},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
       "id": 6,
       "targets": [
         {
@@ -100,14 +178,32 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "description": "Engine metrics from vLLM :8000/metrics — not from gateway X-Technique. Empty if vLLM was not started with speculative decoding (draft/spec flags). Crew labels like speculative_decoding or combined only tag llm_gateway_* / JSONL; they do not turn this on.",
-      "fieldConfig": {"defaults": {"unit": "percentunit", "min": 0, "max": 1}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 23},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Engine metrics from vLLM :8000/metrics \u2014 not from gateway X-Technique. Empty if vLLM was not started with speculative decoding (draft/spec flags). Crew labels like speculative_decoding or combined only tag gateway_* / JSONL; they do not turn this on.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
       "id": 7,
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "vllm:spec_decode_draft_acceptance_rate",
           "legendFormat": "draft_acceptance_rate (gauge, vllm:)",
@@ -115,7 +211,10 @@
           "refId": "A"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "sum(rate(vllm:spec_decode_num_accepted_tokens_total[5m])) / sum(rate(vllm:spec_decode_num_draft_tokens_total[5m]))",
           "legendFormat": "accepted/draft (counters, vllm:)",
@@ -123,7 +222,10 @@
           "refId": "B"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "vllm_spec_decode_draft_acceptance_rate",
           "legendFormat": "draft_acceptance_rate (legacy vllm_)",
@@ -131,7 +233,10 @@
           "refId": "C"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
           "expr": "sum(rate(vllm_spec_decode_num_accepted_tokens_total[5m])) / sum(rate(vllm_spec_decode_num_draft_tokens_total[5m]))",
           "legendFormat": "accepted/draft (legacy vllm_)",
@@ -145,11 +250,19 @@
   ],
   "refresh": "10s",
   "schemaVersion": 39,
-  "tags": ["vllm", "texttinyllama"],
-  "templating": {"list": []},
-  "time": {"from": "now-1h", "to": "now"},
+  "tags": [
+    "vllm",
+    "texttinyllama"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "timezone": "browser",
-  "title": "vLLM — prefill vs decode",
+  "title": "vLLM \u2014 prefill vs decode",
   "uid": "tt-vllm-overview",
   "version": 7
 }

--- a/monitoring/grafana_dashboards/technique-cost.json
+++ b/monitoring/grafana_dashboards/technique-cost.json
@@ -1,0 +1,115 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [{"title": "Jaeger UI", "type": "link", "url": "http://localhost:16686", "icon": "external link"}],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 4, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "content": "## Technique + cost (gateway)\n\n**Labels:** `technique` = request label (`X-Technique` / crew `--technique`). `server_profile` = `VLLM_SERVER_PROFILE` in `.env` (name for the vLLM server flag set you are running on Lambda). Align them when comparing.\n\n**Cost:** `duration_s/3600 * GPU_HOURLY_COST_USD` → `llm_gateway_estimated_gpu_cost_usd_total`.\n\n**Traces:** `X-Trace-Id` → Jaeger.\n\n**Optional:** `VLLM_BACKEND_MAP_JSON` routes each technique to a different vLLM base URL (e.g. another port on the instance).",
+        "mode": "markdown"
+      },
+      "title": "How to read this board",
+      "type": "text"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "currencyUSD"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "id": 2,
+      "targets": [
+        {
+          "expr": "sum by (technique, server_profile) (rate(llm_gateway_estimated_gpu_cost_usd_total[5m]))",
+          "legendFormat": "{{technique}} / {{server_profile}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Estimated GPU $/s by technique (rate of counter)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "currencyUSD"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "id": 3,
+      "description": "Subtracts aggregate baseline $/s from each series (scalar broadcast). `or vector(0)` inside scalar() keeps the graph alive if no `technique=baseline` traffic in the range.",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "sum by (technique, server_profile) (rate(llm_gateway_estimated_gpu_cost_usd_total[5m])) - scalar(sum(rate(llm_gateway_estimated_gpu_cost_usd_total{technique=\"baseline\"}[5m])) or vector(0))",
+          "legendFormat": "{{technique}} / {{server_profile}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cost rate delta vs baseline",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+      "id": 4,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(llm_gateway_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{technique}} / {{server_profile}} p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway E2E latency p95 by technique",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+      "id": 5,
+      "targets": [
+        {
+          "expr": "sum by (technique, server_profile) (rate(llm_gateway_prompt_tokens_total[5m]))",
+          "legendFormat": "prompt {{technique}}/{{server_profile}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (technique, server_profile) (rate(llm_gateway_completion_tokens_total[5m]))",
+          "legendFormat": "completion {{technique}}/{{server_profile}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Token rates by technique (from usage)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "none"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 20},
+      "id": 6,
+      "options": {"displayMode": "gradient", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showUnfilled": true},
+      "targets": [
+        {
+          "expr": "sum by (technique, server_profile) (increase(llm_gateway_estimated_gpu_cost_usd_total[1h]))",
+          "legendFormat": "{{technique}} / {{server_profile}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Estimated cost added (last 1h increase) — bar view",
+      "type": "bargauge"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["gateway", "cost", "technique"],
+  "templating": {"list": []},
+  "time": {"from": "now-1h", "to": "now"},
+  "timezone": "browser",
+  "title": "Technique cost + traces",
+  "uid": "tt-technique-cost",
+  "version": 5
+}

--- a/monitoring/grafana_dashboards/technique-cost.json
+++ b/monitoring/grafana_dashboards/technique-cost.json
@@ -1,30 +1,60 @@
 {
-  "annotations": {"list": []},
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [{"title": "Jaeger UI", "type": "link", "url": "http://localhost:16686", "icon": "external link"}],
+  "links": [
+    {
+      "title": "Jaeger UI",
+      "type": "link",
+      "url": "http://localhost:16686",
+      "icon": "external link"
+    }
+  ],
   "panels": [
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "gridPos": {"h": 4, "w": 24, "x": 0, "y": 0},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "options": {
-        "content": "## Technique + cost (gateway)\n\n**Labels:** `technique` = request label (`X-Technique` / crew `--technique`). `server_profile` = `VLLM_SERVER_PROFILE` in `.env` (name for the vLLM server flag set you are running on Lambda). Align them when comparing.\n\n**Cost:** `duration_s/3600 * GPU_HOURLY_COST_USD` → `llm_gateway_estimated_gpu_cost_usd_total`.\n\n**Traces:** `X-Trace-Id` → Jaeger.\n\n**Optional:** `VLLM_BACKEND_MAP_JSON` routes each technique to a different vLLM base URL (e.g. another port on the instance).",
+        "content": "## Technique + cost (gateway)\n\n**Labels:** `technique` = request label (`X-Technique` / crew `--technique`). `server_profile` = `VLLM_SERVER_PROFILE` in `.env` (name for the vLLM server flag set you are running on Lambda). Align them when comparing.\n\n**Cost:** `duration_s/3600 * GPU_HOURLY_COST_USD` \u2192 `gateway_estimated_gpu_cost_usd_total`.\n\n**Traces:** `X-Trace-Id` \u2192 Jaeger.\n\n**Optional:** `VLLM_BACKEND_MAP_JSON` routes each technique to a different vLLM base URL (e.g. another port on the instance).",
         "mode": "markdown"
       },
       "title": "How to read this board",
       "type": "text"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "currencyUSD"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
       "id": 2,
       "targets": [
         {
-          "expr": "sum by (technique, server_profile) (rate(llm_gateway_estimated_gpu_cost_usd_total[5m]))",
+          "expr": "sum by (technique, server_profile) (rate(gateway_gpu_cost_usd_total[5m]))",
           "legendFormat": "{{technique}} / {{server_profile}}",
           "refId": "A"
         }
@@ -33,16 +63,32 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "currencyUSD"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
       "id": 3,
       "description": "Subtracts aggregate baseline $/s from each series (scalar broadcast). `or vector(0)` inside scalar() keeps the graph alive if no `technique=baseline` traffic in the range.",
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
-          "expr": "sum by (technique, server_profile) (rate(llm_gateway_estimated_gpu_cost_usd_total[5m])) - scalar(sum(rate(llm_gateway_estimated_gpu_cost_usd_total{technique=\"baseline\"}[5m])) or vector(0))",
+          "expr": "sum by (technique, server_profile) (rate(gateway_gpu_cost_usd_total[5m])) - scalar(sum(rate(gateway_gpu_cost_usd_total{technique=\"baseline\"}[5m])) or vector(0))",
           "legendFormat": "{{technique}} / {{server_profile}}",
           "range": true,
           "refId": "A"
@@ -52,13 +98,26 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
       "id": 4,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(llm_gateway_request_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(gateway_request_duration_seconds_bucket[5m])))",
           "legendFormat": "{{technique}} / {{server_profile}} p95",
           "refId": "A"
         }
@@ -67,18 +126,31 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
       "id": 5,
       "targets": [
         {
-          "expr": "sum by (technique, server_profile) (rate(llm_gateway_prompt_tokens_total[5m]))",
+          "expr": "sum by (technique, server_profile) (rate(gateway_tokens_total{type=\"prompt\"}[5m]))",
           "legendFormat": "prompt {{technique}}/{{server_profile}}",
           "refId": "A"
         },
         {
-          "expr": "sum by (technique, server_profile) (rate(llm_gateway_completion_tokens_total[5m]))",
+          "expr": "sum by (technique, server_profile) (rate(gateway_tokens_total{type=\"completion\"}[5m]))",
           "legendFormat": "completion {{technique}}/{{server_profile}}",
           "refId": "B"
         }
@@ -87,27 +159,60 @@
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"unit": "none"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 20},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
       "id": 6,
-      "options": {"displayMode": "gradient", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showUnfilled": true},
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
       "targets": [
         {
-          "expr": "sum by (technique, server_profile) (increase(llm_gateway_estimated_gpu_cost_usd_total[1h]))",
+          "expr": "sum by (technique, server_profile) (increase(gateway_gpu_cost_usd_total[1h]))",
           "legendFormat": "{{technique}} / {{server_profile}}",
           "refId": "A"
         }
       ],
-      "title": "Estimated cost added (last 1h increase) — bar view",
+      "title": "Estimated cost added (last 1h increase) \u2014 bar view",
       "type": "bargauge"
     }
   ],
   "refresh": "10s",
   "schemaVersion": 39,
-  "tags": ["gateway", "cost", "technique"],
-  "templating": {"list": []},
-  "time": {"from": "now-1h", "to": "now"},
+  "tags": [
+    "gateway",
+    "cost",
+    "technique"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "timezone": "browser",
   "title": "Technique cost + traces",
   "uid": "tt-technique-cost",

--- a/monitoring/grafana_dashboards/tinyllama-ops.json
+++ b/monitoring/grafana_dashboards/tinyllama-ops.json
@@ -1,0 +1,112 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {"title": "Jaeger UI", "type": "link", "url": "http://localhost:16686", "icon": "external link"}
+  ],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "**vLLM :8000/metrics** (job `vllm_tunnel`). KV cache fill, decode/TTFT pressure, and throughput — not Crew `--technique` labels. Metric names vary by vLLM version (`vllm:` vs `vllm_`).",
+      "fieldConfig": {
+        "defaults": {"unit": "short", "custom": {"drawStyle": "line", "fillOpacity": 8, "spanNulls": false}},
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": "KV cache"}, "properties": [{"id": "unit", "value": "percentunit"}, {"id": "min", "value": 0}, {"id": "max", "value": 1}]},
+          {"matcher": {"id": "byRegexp", "options": "Generation tok/s"}, "properties": [{"id": "unit", "value": "tps"}]},
+          {"matcher": {"id": "byRegexp", "options": "p95 inter-token"}, "properties": [{"id": "unit", "value": "s"}]},
+          {"matcher": {"id": "byRegexp", "options": "p95 engine TTFT"}, "properties": [{"id": "unit", "value": "s"}]}
+        ]
+      },
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"expr": "vllm:kv_cache_usage_perc", "legendFormat": "KV cache", "refId": "A"},
+        {"expr": "sum(rate(vllm:generation_tokens_total[1m]))", "legendFormat": "Generation tok/s", "refId": "B"},
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:inter_token_latency_seconds_bucket[5m])))",
+          "legendFormat": "p95 inter-token (decode step)",
+          "refId": "C"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:time_to_first_token_seconds_bucket[5m])))",
+          "legendFormat": "p95 engine TTFT",
+          "refId": "D"
+        }
+      ],
+      "title": "1 — GPU / engine (vLLM)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "**Gateway :9101/metrics** — what each experiment run did: `technique` = `X-Technique` / `crew.py --technique`; `server_profile` = `VLLM_SERVER_PROFILE` in `.env`.",
+      "fieldConfig": {
+        "defaults": {"unit": "short", "custom": {"drawStyle": "line", "fillOpacity": 8}},
+        "overrides": [
+          {"matcher": {"id": "byRegexp", "options": "req/s"}, "properties": [{"id": "unit", "value": "reqps"}]},
+          {"matcher": {"id": "byRegexp", "options": "p95 E2E"}, "properties": [{"id": "unit", "value": "s"}]},
+          {"matcher": {"id": "byRegexp", "options": "completion tok/s"}, "properties": [{"id": "unit", "value": "tps"}]}
+        ]
+      },
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 10},
+      "id": 2,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {
+          "expr": "sum by (technique, server_profile) (rate(llm_gateway_requests_total[5m]))",
+          "legendFormat": "req/s {{technique}} / {{server_profile}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(llm_gateway_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 E2E {{technique}} / {{server_profile}}",
+          "refId": "B"
+        },
+        {
+          "expr": "sum by (technique, server_profile) (rate(llm_gateway_completion_tokens_total[5m]))",
+          "legendFormat": "completion tok/s {{technique}} / {{server_profile}}",
+          "refId": "C"
+        }
+      ],
+      "title": "2 — Runs (gateway, by technique)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "Estimated rental $ from gateway wall time × `GPU_HOURLY_COST_USD` (and optional Lambda API). Delta subtracts aggregate **baseline** $/s (scalar); stays defined if baseline had no traffic in range.",
+      "fieldConfig": {"defaults": {"unit": "currencyUSD", "custom": {"drawStyle": "line", "fillOpacity": 8}}},
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 20},
+      "id": 3,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {
+          "expr": "sum by (technique, server_profile) (rate(llm_gateway_estimated_gpu_cost_usd_total[5m]))",
+          "legendFormat": "$/s {{technique}} / {{server_profile}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "editorMode": "code",
+          "expr": "sum by (technique, server_profile) (rate(llm_gateway_estimated_gpu_cost_usd_total[5m])) - scalar(sum(rate(llm_gateway_estimated_gpu_cost_usd_total{technique=\"baseline\"}[5m])) or vector(0))",
+          "legendFormat": "Δ $/s vs baseline {{technique}} / {{server_profile}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "3 — Cost (gateway model)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["tinyllama", "gpu", "runs", "cost"],
+  "templating": {"list": []},
+  "time": {"from": "now-1h", "to": "now"},
+  "timezone": "browser",
+  "title": "TinyLlama — GPU, runs & cost",
+  "uid": "tt-tinyllama-ops",
+  "version": 1
+}

--- a/monitoring/grafana_dashboards/tinyllama-ops.json
+++ b/monitoring/grafana_dashboards/tinyllama-ops.json
@@ -1,31 +1,122 @@
 {
-  "annotations": {"list": []},
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
   "links": [
-    {"title": "Jaeger UI", "type": "link", "url": "http://localhost:16686", "icon": "external link"}
+    {
+      "title": "Jaeger UI",
+      "type": "link",
+      "url": "http://localhost:16686",
+      "icon": "external link"
+    }
   ],
   "panels": [
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "description": "**vLLM :8000/metrics** (job `vllm_tunnel`). KV cache fill, decode/TTFT pressure, and throughput — not Crew `--technique` labels. Metric names vary by vLLM version (`vllm:` vs `vllm_`).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "**vLLM :8000/metrics** (job `vllm_standard / vllm_optimized`). KV cache fill, decode/TTFT pressure, and throughput \u2014 not Crew `--technique` labels. Metric names vary by vLLM version (`vllm:` vs `vllm_`).",
       "fieldConfig": {
-        "defaults": {"unit": "short", "custom": {"drawStyle": "line", "fillOpacity": 8, "spanNulls": false}},
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "spanNulls": false
+          }
+        },
         "overrides": [
-          {"matcher": {"id": "byRegexp", "options": "KV cache"}, "properties": [{"id": "unit", "value": "percentunit"}, {"id": "min", "value": 0}, {"id": "max", "value": 1}]},
-          {"matcher": {"id": "byRegexp", "options": "Generation tok/s"}, "properties": [{"id": "unit", "value": "tps"}]},
-          {"matcher": {"id": "byRegexp", "options": "p95 inter-token"}, "properties": [{"id": "unit", "value": "s"}]},
-          {"matcher": {"id": "byRegexp", "options": "p95 engine TTFT"}, "properties": [{"id": "unit", "value": "s"}]}
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "KV cache"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "Generation tok/s"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "tps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "p95 inter-token"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "p95 engine TTFT"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
         ]
       },
-      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
-      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
-        {"expr": "vllm:kv_cache_usage_perc", "legendFormat": "KV cache", "refId": "A"},
-        {"expr": "sum(rate(vllm:generation_tokens_total[1m]))", "legendFormat": "Generation tok/s", "refId": "B"},
+        {
+          "expr": "vllm:kv_cache_usage_perc",
+          "legendFormat": "KV cache",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(vllm:generation_tokens_total[1m]))",
+          "legendFormat": "Generation tok/s",
+          "refId": "B"
+        },
         {
           "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:inter_token_latency_seconds_bucket[5m])))",
           "legendFormat": "p95 inter-token (decode step)",
@@ -37,76 +128,170 @@
           "refId": "D"
         }
       ],
-      "title": "1 — GPU / engine (vLLM)",
+      "title": "1 \u2014 GPU / engine (vLLM)",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "description": "**Gateway :9101/metrics** — what each experiment run did: `technique` = `X-Technique` / `crew.py --technique`; `server_profile` = `VLLM_SERVER_PROFILE` in `.env`.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "**Gateway :9101/metrics** \u2014 what each experiment run did: `technique` = `X-Technique` / `crew.py --technique`; `server_profile` = `VLLM_SERVER_PROFILE` in `.env`.",
       "fieldConfig": {
-        "defaults": {"unit": "short", "custom": {"drawStyle": "line", "fillOpacity": 8}},
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8
+          }
+        },
         "overrides": [
-          {"matcher": {"id": "byRegexp", "options": "req/s"}, "properties": [{"id": "unit", "value": "reqps"}]},
-          {"matcher": {"id": "byRegexp", "options": "p95 E2E"}, "properties": [{"id": "unit", "value": "s"}]},
-          {"matcher": {"id": "byRegexp", "options": "completion tok/s"}, "properties": [{"id": "unit", "value": "tps"}]}
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "req/s"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "p95 E2E"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "completion tok/s"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "tps"
+              }
+            ]
+          }
         ]
       },
-      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 10},
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
       "id": 2,
-      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
         {
-          "expr": "sum by (technique, server_profile) (rate(llm_gateway_requests_total[5m]))",
+          "expr": "sum by (technique, server_profile) (rate(gateway_requests_total[5m]))",
           "legendFormat": "req/s {{technique}} / {{server_profile}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(llm_gateway_request_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, technique, server_profile) (rate(gateway_request_duration_seconds_bucket[5m])))",
           "legendFormat": "p95 E2E {{technique}} / {{server_profile}}",
           "refId": "B"
         },
         {
-          "expr": "sum by (technique, server_profile) (rate(llm_gateway_completion_tokens_total[5m]))",
+          "expr": "sum by (technique, server_profile) (rate(gateway_tokens_total{type=\"completion\"}[5m]))",
           "legendFormat": "completion tok/s {{technique}} / {{server_profile}}",
           "refId": "C"
         }
       ],
-      "title": "2 — Runs (gateway, by technique)",
+      "title": "2 \u2014 Runs (gateway, by technique)",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "description": "Estimated rental $ from gateway wall time × `GPU_HOURLY_COST_USD` (and optional Lambda API). Delta subtracts aggregate **baseline** $/s (scalar); stays defined if baseline had no traffic in range.",
-      "fieldConfig": {"defaults": {"unit": "currencyUSD", "custom": {"drawStyle": "line", "fillOpacity": 8}}},
-      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 20},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Estimated rental $ from gateway wall time \u00d7 `GPU_HOURLY_COST_USD` (and optional Lambda API). Delta subtracts aggregate **baseline** $/s (scalar); stays defined if baseline had no traffic in range.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8
+          }
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
       "id": 3,
-      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
         {
-          "expr": "sum by (technique, server_profile) (rate(llm_gateway_estimated_gpu_cost_usd_total[5m]))",
+          "expr": "sum by (technique, server_profile) (rate(gateway_gpu_cost_usd_total[5m]))",
           "legendFormat": "$/s {{technique}} / {{server_profile}}",
           "refId": "A"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "editorMode": "code",
-          "expr": "sum by (technique, server_profile) (rate(llm_gateway_estimated_gpu_cost_usd_total[5m])) - scalar(sum(rate(llm_gateway_estimated_gpu_cost_usd_total{technique=\"baseline\"}[5m])) or vector(0))",
-          "legendFormat": "Δ $/s vs baseline {{technique}} / {{server_profile}}",
+          "expr": "sum by (technique, server_profile) (rate(gateway_gpu_cost_usd_total[5m])) - scalar(sum(rate(gateway_gpu_cost_usd_total{technique=\"baseline\"}[5m])) or vector(0))",
+          "legendFormat": "\u0394 $/s vs baseline {{technique}} / {{server_profile}}",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "3 — Cost (gateway model)",
+      "title": "3 \u2014 Cost (gateway model)",
       "type": "timeseries"
     }
   ],
   "refresh": "10s",
   "schemaVersion": 39,
-  "tags": ["tinyllama", "gpu", "runs", "cost"],
-  "templating": {"list": []},
-  "time": {"from": "now-1h", "to": "now"},
+  "tags": [
+    "tinyllama",
+    "gpu",
+    "runs",
+    "cost"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "timezone": "browser",
-  "title": "TinyLlama — GPU, runs & cost",
+  "title": "TinyLlama \u2014 GPU, runs & cost",
   "uid": "tt-tinyllama-ops",
   "version": 1
 }

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,33 @@
+# monitoring/prometheus.yml
+#
+# Scrape targets:
+#   gateway        — Prometheus metrics on GATEWAY_METRICS_PORT (default 9101), served by
+#                    the local gateway process. Docker resolves host.docker.internal → host.
+#
+#   vllm_standard  — Modal vLLM Gemma4 standard deployment  (server_profile=default)
+#   vllm_optimized — Modal vLLM Gemma4 optimized deployment (server_profile=optimized)
+#
+# Both vLLM targets expose /metrics directly over HTTPS on Modal.
+# Set VLLM_SERVER_PROFILE in .env to label gateway metrics accordingly.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: gateway
+    static_configs:
+      - targets: ["host.docker.internal:9101"]
+    metrics_path: /metrics
+
+  - job_name: vllm_standard
+    scheme: https
+    static_configs:
+      - targets: ["ingo-villnow--vllm-gemma4-standard-serve.modal.run"]
+    metrics_path: /metrics
+
+  - job_name: vllm_optimized
+    scheme: https
+    static_configs:
+      - targets: ["ingo-villnow--vllm-gemma4-optimized-serve.modal.run"]
+    metrics_path: /metrics


### PR DESCRIPTION
## Summary
- `monitoring/docker-compose.yml`: Prometheus on `:9090` + Grafana on `:3000`; Linux `extra_hosts` for `host.docker.internal`
- `monitoring/prometheus.yml`: three scrape jobs — `gateway` (`:9101`), `vllm_standard` and `vllm_optimized` scraped directly from Modal over HTTPS (no SSH tunnel needed)
- `monitoring/grafana/provisioning`: auto-provisioned Prometheus datasource + dashboard folder provider
- `monitoring/grafana_dashboards`: four dashboards — gateway-proxy, overview, technique-cost, tinyllama-ops

README updated: env vars table, Prometheus metrics docs, `X-Technique` header usage, monitoring stack quickstart, updated config.yaml example + curl examples to Gemma4 backends.

## Test plan
- [x] `uv run pytest` — 60 passed
- [x] `cd monitoring && docker compose up -d` — both services start
- [x] `http://localhost:9090/targets` — gateway shows **UP**; vllm targets reachable when Modal apps are running
- [x] `http://localhost:3000` — Grafana loads with Prometheus datasource pre-configured (admin/admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)