### PR TITLE
feat: migrate gateway to FastAPI (closes #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ uv run pytest
 uv run pytest tests/test_gateway.py::test_routing_by_model_echo   # single test
 ```
 
-The suite starts real `HTTPServer` instances on free ports and uses [respx](https://lundberg.github.io/respx/) to mock backend `httpx` calls. No running backend is required.
+The suite uses a FastAPI `TestClient` and [respx](https://lundberg.github.io/respx/) to mock backend `httpx` calls. No running backend is required.
 
 **60 tests** covering: GET endpoints, echo shape, request-ID, validation errors (400), auth (401), SSE streaming, backend proxy, response normalization, multi-backend routing, metrics, `latency_ms` in usage, Prometheus counter/histogram/gauge behaviour, `X-Technique` label propagation.
 

--- a/main.py
+++ b/main.py
@@ -7,11 +7,13 @@ import logging
 import time
 import uuid
 from dataclasses import dataclass, field
-from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any
+from typing import Any, AsyncGenerator
 
 import httpx
+import prometheus_client
 from dotenv import load_dotenv
+from fastapi import Depends, FastAPI, HTTPException, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
 import os
 from pathlib import Path
 
@@ -53,7 +55,7 @@ settings = Settings()
 
 
 # ---------------------------------------------------------------------------
-# Multi-backend config (loaded once at startup; None if no config.yaml)
+# Multi-backend config
 # ---------------------------------------------------------------------------
 
 from gateway.config import GatewayConfig, load_config  # noqa: E402
@@ -69,15 +71,13 @@ from gateway.prom_metrics import (  # noqa: E402
     TTFT_SECONDS,
 )
 
-# Load config.yaml if present; otherwise gateway_config stays None and the
-# handler falls back to the legacy settings.backend_url path.
 gateway_config: GatewayConfig | None = (
     load_config() if Path("config.yaml").exists() else None
 )
 
 
 # ---------------------------------------------------------------------------
-# In-memory metrics
+# In-memory metrics (legacy JSON endpoint)
 # ---------------------------------------------------------------------------
 
 
@@ -94,19 +94,13 @@ metrics = Metrics()
 
 
 # ---------------------------------------------------------------------------
-# Response normalization
+# Response helpers
 # ---------------------------------------------------------------------------
 
 
 def _normalize_response(
     data: dict[str, Any], request_id: str, latency_ms: float = 0.0
 ) -> dict[str, Any]:
-    """Return a clean, spec-compliant response dict regardless of backend shape.
-
-    Only the documented fields are included; any extra keys sent by the backend
-    (e.g. created, system_fingerprint, timings, logprobs) are silently dropped
-    so that all backends produce an identical response contract.
-    """
     clean_choices = []
     for choice in data.get("choices", []):
         msg = choice.get("message", {})
@@ -141,68 +135,6 @@ def _normalize_response(
     }
 
 
-# ---------------------------------------------------------------------------
-# Request validation
-# ---------------------------------------------------------------------------
-
-
-def _validate_body(body: dict[str, Any]) -> str | None:
-    """Validate request body fields. Returns an error key or None if valid."""
-    # model: string if present
-    model = body.get("model")
-    if model is not None and not isinstance(model, str):
-        return "invalid_model"
-
-    # messages: already checked non-empty above; validate each element
-    messages = body.get("messages", [])
-    for msg in messages:
-        if not isinstance(msg, dict):
-            return "invalid_messages"
-        if "role" not in msg or "content" not in msg:
-            return "invalid_messages"
-        if msg["role"] not in ("system", "user", "assistant"):
-            return "invalid_messages"
-
-    # stream: boolean if present
-    stream = body.get("stream")
-    if stream is not None and not isinstance(stream, bool):
-        return "invalid_stream"
-
-    # max_tokens: positive integer in sane range if present
-    max_tokens = body.get("max_tokens")
-    if max_tokens is not None:
-        if not isinstance(max_tokens, int) or isinstance(max_tokens, bool):
-            return "invalid_max_tokens"
-        if max_tokens < 1 or max_tokens > 100_000:
-            return "invalid_max_tokens"
-
-    # temperature: float/int in [0, 2] if present
-    temperature = body.get("temperature")
-    if temperature is not None:
-        if not isinstance(temperature, (int, float)) or isinstance(temperature, bool):
-            return "invalid_temperature"
-        if temperature < 0 or temperature > 2:
-            return "invalid_temperature"
-
-    # stop: string or list of strings if present
-    stop = body.get("stop")
-    if stop is not None:
-        if isinstance(stop, str):
-            pass
-        elif isinstance(stop, list):
-            if not all(isinstance(s, str) for s in stop):
-                return "invalid_stop"
-        else:
-            return "invalid_stop"
-
-    return None
-
-
-# ---------------------------------------------------------------------------
-# Helper: build an OpenAI-shaped response dict
-# ---------------------------------------------------------------------------
-
-
 def build_response(
     request_id: str,
     content: str,
@@ -232,542 +164,524 @@ def build_response(
 
 
 # ---------------------------------------------------------------------------
-# Gateway HTTP handler
+# Metrics recording
 # ---------------------------------------------------------------------------
 
 
-class GatewayHandler(BaseHTTPRequestHandler):
-    """Handle all incoming HTTP requests for the inference gateway."""
+def record_metrics(
+    status: int,
+    latency_ms: float,
+    prompt_tokens: int,
+    completion_tokens: int,
+    model: str = "unknown",
+    technique: str = "baseline",
+    server_profile: str = "default",
+) -> None:
+    metrics.request_count += 1
+    metrics.total_latency_ms += latency_ms
+    metrics.prompt_tokens_total += prompt_tokens
+    metrics.completion_tokens_total += completion_tokens
+    if status >= 400:
+        metrics.error_count += 1
 
-    # Suppress default access logging — we do structured logging instead.
-    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
-        pass
+    latency_s = latency_ms / 1000.0
+    REQUESTS_TOTAL.labels(
+        status_code=str(status),
+        model=model,
+        technique=technique,
+        server_profile=server_profile,
+    ).inc()
+    REQUEST_DURATION_SECONDS.labels(
+        technique=technique,
+        server_profile=server_profile,
+    ).observe(latency_s)
+    TOKENS_TOTAL.labels(type="prompt").inc(prompt_tokens)
+    TOKENS_TOTAL.labels(type="completion").inc(completion_tokens)
+    if status >= 400:
+        ERRORS_TOTAL.labels(
+            status_code=str(status),
+            technique=technique,
+            server_profile=server_profile,
+        ).inc()
+    cost = latency_s * settings.gpu_hourly_cost_usd / 3600.0
+    GPU_COST_USD_TOTAL.labels(
+        technique=technique,
+        server_profile=server_profile,
+    ).inc(cost)
 
-    # ------------------------------------------------------------------
-    # GET routes
-    # ------------------------------------------------------------------
 
-    def do_GET(self) -> None:
-        if self.path == "/healthz":
-            self._send_json(200, {"status": "ok"})
-        elif self.path == "/metrics":
-            count = metrics.request_count
-            avg_latency_ms = metrics.total_latency_ms / count if count > 0 else 0.0
-            self._send_json(
-                200,
+# ---------------------------------------------------------------------------
+# Request validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_body(body: dict[str, Any]) -> str | None:
+    model = body.get("model")
+    if model is not None and not isinstance(model, str):
+        return "invalid_model"
+
+    messages = body.get("messages", [])
+    for msg in messages:
+        if not isinstance(msg, dict):
+            return "invalid_messages"
+        if "role" not in msg or "content" not in msg:
+            return "invalid_messages"
+        if msg["role"] not in ("system", "user", "assistant"):
+            return "invalid_messages"
+
+    stream = body.get("stream")
+    if stream is not None and not isinstance(stream, bool):
+        return "invalid_stream"
+
+    max_tokens = body.get("max_tokens")
+    if max_tokens is not None:
+        if not isinstance(max_tokens, int) or isinstance(max_tokens, bool):
+            return "invalid_max_tokens"
+        if max_tokens < 1 or max_tokens > 100_000:
+            return "invalid_max_tokens"
+
+    temperature = body.get("temperature")
+    if temperature is not None:
+        if not isinstance(temperature, (int, float)) or isinstance(temperature, bool):
+            return "invalid_temperature"
+        if temperature < 0 or temperature > 2:
+            return "invalid_temperature"
+
+    stop = body.get("stop")
+    if stop is not None:
+        if isinstance(stop, str):
+            pass
+        elif isinstance(stop, list):
+            if not all(isinstance(s, str) for s in stop):
+                return "invalid_stop"
+        else:
+            return "invalid_stop"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Auth dependency
+# ---------------------------------------------------------------------------
+
+
+def check_auth(request: Request) -> None:
+    if settings.api_key is None:
+        return
+    auth_header = request.headers.get("Authorization", "")
+    token: str | None = None
+    if auth_header.startswith("Bearer "):
+        token = auth_header[7:]
+    elif auth_header.startswith("Api-Key "):
+        token = auth_header[8:]
+    if token != settings.api_key:
+        raise HTTPException(status_code=401, detail={"error": "unauthorized"})
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+
+app = FastAPI(title="Inference Gateway")
+
+
+@app.exception_handler(HTTPException)
+async def _http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    if isinstance(exc.detail, dict):
+        return JSONResponse(status_code=exc.status_code, content=exc.detail)
+    return JSONResponse(status_code=exc.status_code, content={"error": str(exc.detail)})
+
+
+@app.get("/healthz")
+async def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/metrics")
+async def metrics_json() -> dict[str, Any]:
+    count = metrics.request_count
+    avg_latency_ms = metrics.total_latency_ms / count if count > 0 else 0.0
+    return {
+        "request_count": count,
+        "error_count": metrics.error_count,
+        "avg_latency_ms": round(avg_latency_ms, 2),
+        "prompt_tokens_total": metrics.prompt_tokens_total,
+        "completion_tokens_total": metrics.completion_tokens_total,
+    }
+
+
+@app.get("/v1/backends")
+async def list_backends() -> dict[str, Any]:
+    if gateway_config is None:
+        raise HTTPException(status_code=404, detail={"error": "not_found"})
+    return {
+        "backends": [
+            {"name": b.name, "type": type(b).__name__}
+            for b in gateway_config.all_backends
+        ],
+        "default": gateway_config.default_backend.name,
+    }
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(
+    request: Request, _auth: None = Depends(check_auth)
+) -> Response:
+    start = time.monotonic()
+    request_id = (
+        request.headers.get("X-Request-ID")
+        or request.headers.get("Request-Id")
+        or str(uuid.uuid4())
+    )
+    technique = request.headers.get("X-Technique", "baseline")
+    server_profile = settings.vllm_server_profile
+    log = logging.LoggerAdapter(logger, {"request_id": request_id})
+
+    ACTIVE_REQUESTS.inc()
+    try:
+        return await _handle_completions(
+            request, request_id, technique, server_profile, start, log
+        )
+    finally:
+        ACTIVE_REQUESTS.dec()
+
+
+async def _handle_completions(
+    request: Request,
+    request_id: str,
+    technique: str,
+    server_profile: str,
+    start: float,
+    log: logging.LoggerAdapter,
+) -> Response:
+    # Parse body
+    try:
+        body = await request.json()
+    except Exception as exc:
+        log.warning("Bad request body: %s", exc)
+        record_metrics(
+            400,
+            (time.monotonic() - start) * 1000,
+            0,
+            0,
+            technique=technique,
+            server_profile=server_profile,
+        )
+        return JSONResponse({"error": "invalid_json"}, status_code=400)
+
+    # Basic structure check
+    messages = body.get("messages")
+    if not isinstance(messages, list) or not messages:
+        record_metrics(
+            400,
+            (time.monotonic() - start) * 1000,
+            0,
+            0,
+            technique=technique,
+            server_profile=server_profile,
+        )
+        return JSONResponse({"error": "invalid_messages"}, status_code=400)
+
+    # Full validation
+    error = _validate_body(body)
+    if error:
+        record_metrics(
+            400,
+            (time.monotonic() - start) * 1000,
+            0,
+            0,
+            technique=technique,
+            server_profile=server_profile,
+        )
+        return JSONResponse({"error": error}, status_code=400)
+
+    stream = body.get("stream", False)
+    model = body.get("model")
+
+    prompt = ""
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            prompt = msg.get("content", "")
+            break
+
+    forward_body: dict[str, Any] = {
+        "messages": messages,
+        "model": model or "default",
+        "stream": stream,
+    }
+    for key in ("max_tokens", "temperature", "stop"):
+        if key in body:
+            forward_body[key] = body[key]
+
+    if gateway_config is not None:
+        return await _handle_with_config(
+            request_id,
+            forward_body,
+            model,
+            prompt,
+            stream,
+            start,
+            log,
+            technique=technique,
+            server_profile=server_profile,
+        )
+    if settings.backend_url:
+        return await _handle_backend(
+            request_id,
+            forward_body,
+            stream,
+            start,
+            log,
+            technique=technique,
+            server_profile=server_profile,
+        )
+    return await _handle_echo(
+        request_id,
+        prompt,
+        stream,
+        start,
+        log,
+        technique=technique,
+        server_profile=server_profile,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch helpers
+# ---------------------------------------------------------------------------
+
+
+async def _handle_echo(
+    request_id: str,
+    prompt: str,
+    stream: bool,
+    start: float,
+    log: logging.LoggerAdapter,
+    *,
+    technique: str = "baseline",
+    server_profile: str = "default",
+) -> Response:
+    content = f"Echo: {prompt}"
+    prompt_tokens = len(prompt.split())
+    completion_tokens = len(content.split())
+    latency_ms = (time.monotonic() - start) * 1000
+
+    record_metrics(
+        200,
+        latency_ms,
+        prompt_tokens,
+        completion_tokens,
+        technique=technique,
+        server_profile=server_profile,
+    )
+    log.info("POST /v1/chat/completions status=200 latency_ms=%.1f mode=echo", latency_ms)
+
+    if stream:
+        chunk = {
+            "id": request_id,
+            "object": "chat.completion.chunk",
+            "choices": [
                 {
-                    "request_count": count,
-                    "error_count": metrics.error_count,
-                    "avg_latency_ms": round(avg_latency_ms, 2),
-                    "prompt_tokens_total": metrics.prompt_tokens_total,
-                    "completion_tokens_total": metrics.completion_tokens_total,
-                },
-            )
-        elif self.path == "/v1/backends":
-            if gateway_config is not None:
-                self._send_json(
-                    200,
-                    {
-                        "backends": [
-                            {"name": b.name, "type": type(b).__name__}
-                            for b in gateway_config.all_backends
-                        ],
-                        "default": gateway_config.default_backend.name,
-                    },
-                )
-            else:
-                self._send_json(404, {"error": "not_found"})
-        else:
-            self._send_json(404, {"error": "not_found"})
-
-    # ------------------------------------------------------------------
-    # POST routes
-    # ------------------------------------------------------------------
-
-    def do_POST(self) -> None:
-        if not self._check_auth():
-            return
-        if self.path == "/v1/chat/completions":
-            self._handle_chat_completions()
-        else:
-            self._send_json(404, {"error": "not_found"})
-
-    # ------------------------------------------------------------------
-    # /v1/chat/completions implementation
-    # ------------------------------------------------------------------
-
-    def _handle_chat_completions(self) -> None:
-        ACTIVE_REQUESTS.inc()
-        try:
-            self._do_handle_chat_completions()
-        finally:
-            ACTIVE_REQUESTS.dec()
-
-    def _do_handle_chat_completions(self) -> None:
-        start = time.monotonic()
-        request_id = self._get_request_id()
-        technique = self.headers.get("X-Technique", "baseline")
-        server_profile = settings.vllm_server_profile
-        log = logging.LoggerAdapter(logger, {"request_id": request_id})
-
-        # Parse body
-        try:
-            body = self._read_json_body()
-        except (json.JSONDecodeError, ValueError) as exc:
-            log.warning("Bad request body: %s", exc)
-            self._record_metrics(
-                400,
-                (time.monotonic() - start) * 1000,
-                0,
-                0,
-                technique=technique,
-                server_profile=server_profile,
-            )
-            self._send_json(400, {"error": "invalid_json"})
-            return
-
-        # Basic structure check
-        messages = body.get("messages")
-        if not isinstance(messages, list) or not messages:
-            self._record_metrics(
-                400,
-                (time.monotonic() - start) * 1000,
-                0,
-                0,
-                technique=technique,
-                server_profile=server_profile,
-            )
-            self._send_json(400, {"error": "invalid_messages"})
-            return
-
-        # Full validation
-        error = _validate_body(body)
-        if error:
-            self._record_metrics(
-                400,
-                (time.monotonic() - start) * 1000,
-                0,
-                0,
-                technique=technique,
-                server_profile=server_profile,
-            )
-            self._send_json(400, {"error": error})
-            return
-
-        stream = body.get("stream", False)
-
-        # Extract last user message as prompt
-        prompt = ""
-        for msg in reversed(messages):
-            if msg.get("role") == "user":
-                prompt = msg.get("content", "")
-                break
-
-        model = body.get("model")
-
-        # Build a clean forward body with only known fields
-        forward_body: dict[str, Any] = {
-            "messages": messages,
-            "model": model or "default",
-            "stream": stream,
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": content},
+                    "finish_reason": "stop",
+                }
+            ],
         }
-        for key in ("max_tokens", "temperature", "stop"):
-            if key in body:
-                forward_body[key] = body[key]
 
-        # Dispatch — config-based routing takes precedence over legacy settings
-        if gateway_config is not None:
-            self._handle_with_config(
+        async def _sse() -> AsyncGenerator[str, None]:
+            yield f"data: {json.dumps(chunk)}\n\n"
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(
+            _sse(),
+            media_type="text/event-stream",
+            headers={"X-Request-ID": request_id, "Cache-Control": "no-cache"},
+        )
+
+    resp = build_response(
+        request_id,
+        content,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        latency_ms=latency_ms,
+    )
+    return JSONResponse(resp, headers={"X-Request-ID": request_id})
+
+
+async def _handle_with_config(
+    request_id: str,
+    forward_body: dict[str, Any],
+    model: str | None,
+    prompt: str,
+    stream: bool,
+    start: float,
+    log: logging.LoggerAdapter,
+    *,
+    technique: str = "baseline",
+    server_profile: str = "default",
+) -> Response:
+    assert gateway_config is not None
+    backend = gateway_config.get_backend_for_model(model)
+
+    backend_body = {k: v for k, v in forward_body.items() if k != "model"}
+    if isinstance(backend, HttpBackend) and backend.model is not None:
+        backend_body["model"] = backend.model
+
+    if stream:
+        if isinstance(backend, HttpBackend):
+            return await _proxy_stream(
                 request_id,
-                forward_body,
-                model,
-                prompt,
-                stream,
+                backend.completions_url,
+                backend_body,
                 start,
                 log,
                 technique=technique,
                 server_profile=server_profile,
             )
-        elif settings.backend_url:
-            self._handle_backend(
-                request_id,
-                forward_body,
-                stream,
-                start,
-                log,
-                technique=technique,
-                server_profile=server_profile,
-            )
-        else:
-            self._handle_echo(
-                request_id,
-                prompt,
-                stream,
-                start,
-                log,
-                technique=technique,
-                server_profile=server_profile,
-            )
+        return await _handle_echo(
+            request_id, prompt, stream, start, log,
+            technique=technique, server_profile=server_profile,
+        )
 
-    def _handle_echo(
-        self,
-        request_id: str,
-        prompt: str,
-        stream: bool,
-        start: float,
-        log: logging.LoggerAdapter,
-        *,
-        technique: str = "baseline",
-        server_profile: str = "default",
-    ) -> None:
-        content = f"Echo: {prompt}"
-        prompt_tokens = len(prompt.split())
-        completion_tokens = len(content.split())
-
+    try:
+        data = backend.generate(backend_body, request_id)
+    except httpx.TimeoutException:
         latency_ms = (time.monotonic() - start) * 1000
-
-        if stream:
-            self._send_sse_echo(request_id, content)
-        else:
-            resp = build_response(
-                request_id,
-                content,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                latency_ms=latency_ms,
-            )
-            self._send_json(200, resp, request_id=request_id)
-
-        self._record_metrics(
-            200,
-            latency_ms,
-            prompt_tokens,
-            completion_tokens,
-            technique=technique,
-            server_profile=server_profile,
-        )
-        log.info(
-            "POST /v1/chat/completions status=200 latency_ms=%.1f mode=echo", latency_ms
-        )
-
-    def _handle_with_config(
-        self,
-        request_id: str,
-        forward_body: dict[str, Any],
-        model: str | None,
-        prompt: str,
-        stream: bool,
-        start: float,
-        log: logging.LoggerAdapter,
-        *,
-        technique: str = "baseline",
-        server_profile: str = "default",
-    ) -> None:
-        """Route the request through the multi-backend config."""
-        assert gateway_config is not None
-        backend = gateway_config.get_backend_for_model(model)
-
-        # The "model" field in the request is the gateway routing key, not a
-        # backend model name.  Strip it before forwarding so that backends
-        # (e.g. vLLM) do not reject an unknown name.
-        # If the backend config specifies a model override, inject it instead.
-        backend_body = {k: v for k, v in forward_body.items() if k != "model"}
-        if isinstance(backend, HttpBackend) and backend.model is not None:
-            backend_body["model"] = backend.model
-
-        if stream:
-            # Streaming: delegate to echo or proxy path based on backend type
-            if isinstance(backend, HttpBackend):
-                try:
-                    self._proxy_stream(
-                        request_id,
-                        backend.completions_url,
-                        backend_body,
-                        start,
-                        log,
-                        technique=technique,
-                        server_profile=server_profile,
-                    )
-                except httpx.TimeoutException:
-                    latency_ms = (time.monotonic() - start) * 1000
-                    self._record_metrics(
-                        504,
-                        latency_ms,
-                        0,
-                        0,
-                        technique=technique,
-                        server_profile=server_profile,
-                    )
-                    log.error("Backend timeout after %.1f ms", latency_ms)
-                    self._send_json(
-                        504, {"error": "gateway_timeout"}, request_id=request_id
-                    )
-                except httpx.RequestError as exc:
-                    latency_ms = (time.monotonic() - start) * 1000
-                    self._record_metrics(
-                        502,
-                        latency_ms,
-                        0,
-                        0,
-                        technique=technique,
-                        server_profile=server_profile,
-                    )
-                    log.error("Backend connection error: %s", exc)
-                    self._send_json(
-                        502, {"error": "backend_unavailable"}, request_id=request_id
-                    )
-            else:
-                self._handle_echo(
-                    request_id,
-                    prompt,
-                    stream,
-                    start,
-                    log,
-                    technique=technique,
-                    server_profile=server_profile,
-                )
-            return
-
-        # Non-streaming: call backend.generate()
-        try:
-            data = backend.generate(backend_body, request_id)
-        except httpx.TimeoutException:
-            latency_ms = (time.monotonic() - start) * 1000
-            self._record_metrics(
-                504,
-                latency_ms,
-                0,
-                0,
-                technique=technique,
-                server_profile=server_profile,
-            )
-            log.error("Backend %s timeout after %.1f ms", backend.name, latency_ms)
-            self._send_json(504, {"error": "gateway_timeout"}, request_id=request_id)
-            return
-        except httpx.RequestError as exc:
-            latency_ms = (time.monotonic() - start) * 1000
-            self._record_metrics(
-                502,
-                latency_ms,
-                0,
-                0,
-                technique=technique,
-                server_profile=server_profile,
-            )
-            log.error("Backend %s connection error: %s", backend.name, exc)
-            self._send_json(
-                502, {"error": "backend_unavailable"}, request_id=request_id
-            )
-            return
-        except RuntimeError as exc:
-            latency_ms = (time.monotonic() - start) * 1000
-            self._record_metrics(
-                502,
-                latency_ms,
-                0,
-                0,
-                technique=technique,
-                server_profile=server_profile,
-            )
-            log.error("Backend %s error: %s", backend.name, exc)
-            self._send_json(502, {"error": "backend_error"}, request_id=request_id)
-            return
-
+        record_metrics(504, latency_ms, 0, 0, technique=technique, server_profile=server_profile)
+        log.error("Backend %s timeout after %.1f ms", backend.name, latency_ms)
+        return JSONResponse({"error": "gateway_timeout"}, status_code=504, headers={"X-Request-ID": request_id})
+    except httpx.RequestError as exc:
         latency_ms = (time.monotonic() - start) * 1000
-        data = _normalize_response(data, request_id, latency_ms=latency_ms)
-        data["backend"] = backend.name
-
-        usage = data["usage"]
-        prompt_tokens = usage.get("prompt_tokens", 0)
-        completion_tokens = usage.get("completion_tokens", 0)
-
-        self._record_metrics(
-            200,
-            latency_ms,
-            prompt_tokens,
-            completion_tokens,
-            technique=technique,
-            server_profile=server_profile,
-        )
-        log.info(
-            "POST /v1/chat/completions status=200 latency_ms=%.1f mode=config backend=%s",
-            latency_ms,
-            backend.name,
-        )
-        self._send_json(200, data, request_id=request_id)
-
-    def _handle_backend(
-        self,
-        request_id: str,
-        body: dict[str, Any],
-        stream: bool,
-        start: float,
-        log: logging.LoggerAdapter,
-        *,
-        technique: str = "baseline",
-        server_profile: str = "default",
-    ) -> None:
-        assert settings.backend_url is not None
-        url = settings.backend_url.rstrip("/") + "/v1/chat/completions"
-
-        try:
-            if stream:
-                self._proxy_stream(
-                    request_id,
-                    url,
-                    body,
-                    start,
-                    log,
-                    technique=technique,
-                    server_profile=server_profile,
-                )
-            else:
-                self._proxy_non_stream(
-                    request_id,
-                    url,
-                    body,
-                    start,
-                    log,
-                    technique=technique,
-                    server_profile=server_profile,
-                )
-        except httpx.TimeoutException:
-            latency_ms = (time.monotonic() - start) * 1000
-            self._record_metrics(
-                504,
-                latency_ms,
-                0,
-                0,
-                technique=technique,
-                server_profile=server_profile,
-            )
-            log.error("Backend timeout after %.1f ms", latency_ms)
-            self._send_json(504, {"error": "gateway_timeout"}, request_id=request_id)
-        except httpx.RequestError as exc:
-            latency_ms = (time.monotonic() - start) * 1000
-            self._record_metrics(
-                502,
-                latency_ms,
-                0,
-                0,
-                technique=technique,
-                server_profile=server_profile,
-            )
-            log.error("Backend connection error: %s", exc)
-            self._send_json(
-                502, {"error": "backend_unavailable"}, request_id=request_id
-            )
-
-    def _proxy_non_stream(
-        self,
-        request_id: str,
-        url: str,
-        body: dict[str, Any],
-        start: float,
-        log: logging.LoggerAdapter,
-        *,
-        technique: str = "baseline",
-        server_profile: str = "default",
-    ) -> None:
-        with httpx.Client(timeout=60.0) as client:
-            resp = client.post(url, json=body, headers={"X-Technique": technique})
-
-        if resp.status_code >= 500:
-            latency_ms = (time.monotonic() - start) * 1000
-            self._record_metrics(
-                502,
-                latency_ms,
-                0,
-                0,
-                technique=technique,
-                server_profile=server_profile,
-            )
-            log.error("Backend returned %d", resp.status_code)
-            self._send_json(502, {"error": "backend_error"}, request_id=request_id)
-            return
-
-        try:
-            data = resp.json()
-        except Exception:
-            latency_ms = (time.monotonic() - start) * 1000
-            self._record_metrics(
-                502,
-                latency_ms,
-                0,
-                0,
-                technique=technique,
-                server_profile=server_profile,
-            )
-            self._send_json(
-                502, {"error": "backend_invalid_response"}, request_id=request_id
-            )
-            return
-
-        # Normalize response shape and ensure it carries our request-id
+        record_metrics(502, latency_ms, 0, 0, technique=technique, server_profile=server_profile)
+        log.error("Backend %s connection error: %s", backend.name, exc)
+        return JSONResponse({"error": "backend_unavailable"}, status_code=502, headers={"X-Request-ID": request_id})
+    except RuntimeError as exc:
         latency_ms = (time.monotonic() - start) * 1000
-        data = _normalize_response(data, request_id, latency_ms=latency_ms)
-        usage = data["usage"]
-        prompt_tokens = usage.get("prompt_tokens", 0)
-        completion_tokens = usage.get("completion_tokens", 0)
+        record_metrics(502, latency_ms, 0, 0, technique=technique, server_profile=server_profile)
+        log.error("Backend %s error: %s", backend.name, exc)
+        return JSONResponse({"error": "backend_error"}, status_code=502, headers={"X-Request-ID": request_id})
 
-        self._record_metrics(
-            resp.status_code,
-            latency_ms,
-            prompt_tokens,
-            completion_tokens,
-            technique=technique,
-            server_profile=server_profile,
-        )
-        log.info(
-            "POST /v1/chat/completions status=%d latency_ms=%.1f mode=backend",
-            resp.status_code,
-            latency_ms,
-        )
-        self._send_json(resp.status_code, data, request_id=request_id)
+    latency_ms = (time.monotonic() - start) * 1000
+    data = _normalize_response(data, request_id, latency_ms=latency_ms)
+    data["backend"] = backend.name
 
-    def _proxy_stream(
-        self,
-        request_id: str,
-        url: str,
-        body: dict[str, Any],
-        start: float,
-        log: logging.LoggerAdapter,
-        *,
-        technique: str = "baseline",
-        server_profile: str = "default",
-    ) -> None:
-        """Forward SSE chunks from backend to client without buffering."""
-        with httpx.Client(timeout=60.0) as client:
-            with client.stream(
+    usage = data["usage"]
+    record_metrics(
+        200, latency_ms,
+        usage.get("prompt_tokens", 0), usage.get("completion_tokens", 0),
+        technique=technique, server_profile=server_profile,
+    )
+    log.info(
+        "POST /v1/chat/completions status=200 latency_ms=%.1f mode=config backend=%s",
+        latency_ms, backend.name,
+    )
+    return JSONResponse(data, headers={"X-Request-ID": request_id})
+
+
+async def _handle_backend(
+    request_id: str,
+    body: dict[str, Any],
+    stream: bool,
+    start: float,
+    log: logging.LoggerAdapter,
+    *,
+    technique: str = "baseline",
+    server_profile: str = "default",
+) -> Response:
+    assert settings.backend_url is not None
+    url = settings.backend_url.rstrip("/") + "/v1/chat/completions"
+    if stream:
+        return await _proxy_stream(
+            request_id, url, body, start, log,
+            technique=technique, server_profile=server_profile,
+        )
+    return await _proxy_non_stream(
+        request_id, url, body, start, log,
+        technique=technique, server_profile=server_profile,
+    )
+
+
+async def _proxy_non_stream(
+    request_id: str,
+    url: str,
+    body: dict[str, Any],
+    start: float,
+    log: logging.LoggerAdapter,
+    *,
+    technique: str = "baseline",
+    server_profile: str = "default",
+) -> Response:
+    try:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.post(url, json=body, headers={"X-Technique": technique})
+    except httpx.TimeoutException:
+        latency_ms = (time.monotonic() - start) * 1000
+        record_metrics(504, latency_ms, 0, 0, technique=technique, server_profile=server_profile)
+        log.error("Backend timeout after %.1f ms", latency_ms)
+        return JSONResponse({"error": "gateway_timeout"}, status_code=504, headers={"X-Request-ID": request_id})
+    except httpx.RequestError as exc:
+        latency_ms = (time.monotonic() - start) * 1000
+        record_metrics(502, latency_ms, 0, 0, technique=technique, server_profile=server_profile)
+        log.error("Backend connection error: %s", exc)
+        return JSONResponse({"error": "backend_unavailable"}, status_code=502, headers={"X-Request-ID": request_id})
+
+    if resp.status_code >= 500:
+        latency_ms = (time.monotonic() - start) * 1000
+        record_metrics(502, latency_ms, 0, 0, technique=technique, server_profile=server_profile)
+        log.error("Backend returned %d", resp.status_code)
+        return JSONResponse({"error": "backend_error"}, status_code=502, headers={"X-Request-ID": request_id})
+
+    try:
+        data = resp.json()
+    except Exception:
+        latency_ms = (time.monotonic() - start) * 1000
+        record_metrics(502, latency_ms, 0, 0, technique=technique, server_profile=server_profile)
+        return JSONResponse({"error": "backend_invalid_response"}, status_code=502, headers={"X-Request-ID": request_id})
+
+    latency_ms = (time.monotonic() - start) * 1000
+    data = _normalize_response(data, request_id, latency_ms=latency_ms)
+    usage = data["usage"]
+    record_metrics(
+        resp.status_code, latency_ms,
+        usage.get("prompt_tokens", 0), usage.get("completion_tokens", 0),
+        technique=technique, server_profile=server_profile,
+    )
+    log.info(
+        "POST /v1/chat/completions status=%d latency_ms=%.1f mode=backend",
+        resp.status_code, latency_ms,
+    )
+    return JSONResponse(data, status_code=resp.status_code, headers={"X-Request-ID": request_id})
+
+
+async def _proxy_stream(
+    request_id: str,
+    url: str,
+    body: dict[str, Any],
+    start: float,
+    log: logging.LoggerAdapter,
+    *,
+    technique: str = "baseline",
+    server_profile: str = "default",
+) -> Response:
+    async def _stream_gen() -> AsyncGenerator[bytes, None]:
+        prompt_tokens = 0
+        completion_tokens = 0
+        first_chunk = True
+        last_chunk_time = time.monotonic()
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            async with client.stream(
                 "POST", url, json=body, headers={"X-Technique": technique}
             ) as resp:
                 if resp.status_code >= 500:
                     latency_ms = (time.monotonic() - start) * 1000
-                    self._record_metrics(
-                        502,
-                        latency_ms,
-                        0,
-                        0,
-                        technique=technique,
-                        server_profile=server_profile,
-                    )
-                    self._send_json(
-                        502, {"error": "backend_error"}, request_id=request_id
-                    )
+                    record_metrics(502, latency_ms, 0, 0, technique=technique, server_profile=server_profile)
+                    yield json.dumps({"error": "backend_error"}).encode()
                     return
 
-                self.send_response(200)
-                self.send_header("Content-Type", "text/event-stream")
-                self.send_header("Cache-Control", "no-cache")
-                self.send_header("X-Request-ID", request_id)
-                self.end_headers()
-
-                prompt_tokens = 0
-                completion_tokens = 0
-                first_chunk = True
-                last_chunk_time = time.monotonic()
-                for line in resp.iter_lines():
-                    self.wfile.write((line + "\n").encode())
+                async for line in resp.aiter_lines():
+                    yield (line + "\n").encode()
                     if line.startswith("data: ") and line != "data: [DONE]":
                         now = time.monotonic()
                         if first_chunk:
@@ -783,139 +697,23 @@ class GatewayHandler(BaseHTTPRequestHandler):
                                 completion_tokens = usage.get("completion_tokens", 0)
                         except (json.JSONDecodeError, AttributeError):
                             pass
-                self.wfile.write(b"\n")
-                self.wfile.flush()
+                yield b"\n"
 
         latency_ms = (time.monotonic() - start) * 1000
-        self._record_metrics(
-            200,
-            latency_ms,
-            prompt_tokens,
-            completion_tokens,
-            technique=technique,
-            server_profile=server_profile,
+        record_metrics(
+            200, latency_ms, prompt_tokens, completion_tokens,
+            technique=technique, server_profile=server_profile,
         )
         log.info(
             "POST /v1/chat/completions status=200 latency_ms=%.1f mode=backend-stream",
             latency_ms,
         )
 
-    def _send_sse_echo(self, request_id: str, content: str) -> None:
-        """Return a single SSE chunk followed by [DONE] for echo mode."""
-        chunk = {
-            "id": request_id,
-            "object": "chat.completion.chunk",
-            "choices": [
-                {
-                    "index": 0,
-                    "delta": {"role": "assistant", "content": content},
-                    "finish_reason": "stop",
-                }
-            ],
-        }
-        self.send_response(200)
-        self.send_header("Content-Type", "text/event-stream")
-        self.send_header("Cache-Control", "no-cache")
-        self.send_header("X-Request-ID", request_id)
-        self.end_headers()
-        self.wfile.write(f"data: {json.dumps(chunk)}\n\n".encode())
-        self.wfile.write(b"data: [DONE]\n\n")
-        self.wfile.flush()
-
-    # ------------------------------------------------------------------
-    # Auth
-    # ------------------------------------------------------------------
-
-    def _check_auth(self) -> bool:
-        """Return True if auth passes. If auth fails, send 401 and return False."""
-        if settings.api_key is None:
-            return True
-
-        auth_header = self.headers.get("Authorization", "")
-        token: str | None = None
-        if auth_header.startswith("Bearer "):
-            token = auth_header[7:]
-        elif auth_header.startswith("Api-Key "):
-            token = auth_header[8:]
-
-        if token != settings.api_key:
-            self._send_json(401, {"error": "unauthorized"})
-            return False
-        return True
-
-    # ------------------------------------------------------------------
-    # Utility methods
-    # ------------------------------------------------------------------
-
-    def _get_request_id(self) -> str:
-        return (
-            self.headers.get("X-Request-ID")
-            or self.headers.get("Request-Id")
-            or str(uuid.uuid4())
-        )
-
-    def _read_json_body(self) -> dict[str, Any]:
-        length = int(self.headers.get("Content-Length", 0))
-        raw = self.rfile.read(length)
-        return json.loads(raw)
-
-    def _send_json(
-        self,
-        status: int,
-        data: dict[str, Any],
-        *,
-        request_id: str | None = None,
-    ) -> None:
-        body = json.dumps(data).encode()
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        if request_id:
-            self.send_header("X-Request-ID", request_id)
-        self.end_headers()
-        self.wfile.write(body)
-
-    def _record_metrics(
-        self,
-        status: int,
-        latency_ms: float,
-        prompt_tokens: int,
-        completion_tokens: int,
-        model: str = "unknown",
-        technique: str = "baseline",
-        server_profile: str = "default",
-    ) -> None:
-        metrics.request_count += 1
-        metrics.total_latency_ms += latency_ms
-        metrics.prompt_tokens_total += prompt_tokens
-        metrics.completion_tokens_total += completion_tokens
-        if status >= 400:
-            metrics.error_count += 1
-
-        latency_s = latency_ms / 1000.0
-        REQUESTS_TOTAL.labels(
-            status_code=str(status),
-            model=model,
-            technique=technique,
-            server_profile=server_profile,
-        ).inc()
-        REQUEST_DURATION_SECONDS.labels(
-            technique=technique,
-            server_profile=server_profile,
-        ).observe(latency_s)
-        TOKENS_TOTAL.labels(type="prompt").inc(prompt_tokens)
-        TOKENS_TOTAL.labels(type="completion").inc(completion_tokens)
-        if status >= 400:
-            ERRORS_TOTAL.labels(
-                status_code=str(status),
-                technique=technique,
-                server_profile=server_profile,
-            ).inc()
-        cost = latency_s * settings.gpu_hourly_cost_usd / 3600.0
-        GPU_COST_USD_TOTAL.labels(
-            technique=technique,
-            server_profile=server_profile,
-        ).inc(cost)
+    return StreamingResponse(
+        _stream_gen(),
+        media_type="text/event-stream",
+        headers={"X-Request-ID": request_id, "Cache-Control": "no-cache"},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -924,27 +722,15 @@ class GatewayHandler(BaseHTTPRequestHandler):
 
 
 def main() -> None:
-    import prometheus_client
+    import uvicorn
 
     prometheus_client.start_http_server(settings.metrics_port)
-    logger.info(
-        "Prometheus metrics available on port %d",
-        settings.metrics_port,
-        extra={"request_id": "-"},
-    )
+    logger.info("Prometheus metrics available on port %d", settings.metrics_port)
 
-    server = HTTPServer(("0.0.0.0", settings.port), GatewayHandler)
     mode = f"backend={settings.backend_url}" if settings.backend_url else "echo mode"
-    logger.info(
-        "Inference gateway listening on port %d (%s)",
-        settings.port,
-        mode,
-        extra={"request_id": "-"},
-    )
-    try:
-        server.serve_forever()
-    except KeyboardInterrupt:
-        logger.info("Shutting down.", extra={"request_id": "-"})
+    logger.info("Inference gateway listening on port %d (%s)", settings.port, mode)
+
+    uvicorn.run(app, host="0.0.0.0", port=settings.port, log_config=None)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,12 @@ description = "OpenAI-compatible HTTP inference gateway with echo mode and backe
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "fastapi>=0.115",
     "httpx>=0.28",
     "prometheus_client>=0.20",
     "python-dotenv>=1.0",
     "pyyaml>=6.0",
+    "uvicorn>=0.30",
 ]
 
 [project.scripts]

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 import json
-import threading
-import urllib.error
-import urllib.request
 import uuid
-from http.server import HTTPServer
 
 import httpx
 import pytest
 import respx
+from fastapi.testclient import TestClient
 
 import main
 from gateway.backends.http_backend import HttpBackend
@@ -27,29 +24,38 @@ COMPLETION_PAYLOAD = {
 }
 
 
-def _post(url: str, body: dict, headers: dict | None = None, timeout: float = 30.0):
-    """POST JSON body; returns (status, body_dict, response_headers)."""
-    data = json.dumps(body).encode()
-    req = urllib.request.Request(
-        url,
-        data=data,
-        headers={"Content-Type": "application/json", **(headers or {})},
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return resp.status, json.loads(resp.read()), resp.headers
-    except urllib.error.HTTPError as e:
-        return e.code, json.loads(e.read()), e.headers
+def _post(client, path, body: dict, headers: dict | None = None, timeout: float = 30.0):
+    """POST JSON body; returns (status, body_dict, response_headers).
+
+    client can be a TestClient (unit tests) or a full URL string (live tests).
+    For live tests pass the full URL as client and omit path (or pass path="").
+    """
+    if isinstance(client, str):
+        # live test: client is the full URL, path is the body
+        with httpx.Client(timeout=timeout) as c:
+            try:
+                resp = c.post(client, json=path, headers={"Content-Type": "application/json", **(headers or {})})
+                return resp.status_code, resp.json(), resp.headers
+            except httpx.HTTPStatusError as e:
+                return e.response.status_code, e.response.json(), e.response.headers
+    resp = client.post(path, json=body, headers=headers or {})
+    return resp.status_code, resp.json(), resp.headers
 
 
-def _get(url: str):
-    """GET; returns (status, body_dict)."""
-    try:
-        with urllib.request.urlopen(url) as resp:
-            return resp.status, json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        return e.code, json.loads(e.read())
+def _get(client, path: str):
+    """GET; returns (status, body_dict).
+
+    client can be a TestClient (unit tests) or a base URL string (live tests).
+    """
+    if isinstance(client, str):
+        with httpx.Client() as c:
+            try:
+                resp = c.get(client + path)
+                return resp.status_code, resp.json()
+            except httpx.HTTPStatusError as e:
+                return e.response.status_code, e.response.json()
+    resp = client.get(path)
+    return resp.status_code, resp.json()
 
 
 def _live_timeout(backend_name: str, extra: float = 30.0) -> float:
@@ -81,12 +87,8 @@ def gateway(monkeypatch):
         monkeypatch.setattr(main.metrics, f, 0)
     monkeypatch.setattr(main.metrics, "total_latency_ms", 0.0)
 
-    server = HTTPServer(("127.0.0.1", 0), main.GatewayHandler)
-    port = server.server_address[1]
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    yield f"http://127.0.0.1:{port}"
-    server.shutdown()
+    with TestClient(main.app, raise_server_exceptions=False) as client:
+        yield client
 
 
 @pytest.fixture
@@ -104,12 +106,8 @@ def backend_gateway(monkeypatch):
         monkeypatch.setattr(main.metrics, f, 0)
     monkeypatch.setattr(main.metrics, "total_latency_ms", 0.0)
 
-    server = HTTPServer(("127.0.0.1", 0), main.GatewayHandler)
-    port = server.server_address[1]
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    yield f"http://127.0.0.1:{port}"
-    server.shutdown()
+    with TestClient(main.app, raise_server_exceptions=False) as client:
+        yield client
 
 
 # ---------------------------------------------------------------------------
@@ -118,18 +116,18 @@ def backend_gateway(monkeypatch):
 
 
 def test_healthz(gateway):
-    status, body = _get(f"{gateway}/healthz")
+    status, body = _get(gateway, "/healthz")
     assert status == 200
     assert body == {"status": "ok"}
 
 
 def test_unknown_route_get(gateway):
-    status, _ = _get(f"{gateway}/unknown")
+    status, _ = _get(gateway, "/unknown")
     assert status == 404
 
 
 def test_unknown_route_post(gateway):
-    status, _, _ = _post(f"{gateway}/unknown", {})
+    status, _, _ = _post(gateway, "/unknown", {})
     assert status == 404
 
 
@@ -139,7 +137,7 @@ def test_unknown_route_post(gateway):
 
 
 def test_echo_returns_correct_shape(gateway):
-    status, body, _ = _post(f"{gateway}/v1/chat/completions", COMPLETION_PAYLOAD)
+    status, body, _ = _post(gateway, "/v1/chat/completions", COMPLETION_PAYLOAD)
     assert status == 200
     assert "id" in body
     assert "choices" in body
@@ -147,13 +145,13 @@ def test_echo_returns_correct_shape(gateway):
 
 
 def test_echo_content(gateway):
-    _, body, _ = _post(f"{gateway}/v1/chat/completions", COMPLETION_PAYLOAD)
+    _, body, _ = _post(gateway, "/v1/chat/completions", COMPLETION_PAYLOAD)
     content = body["choices"][0]["message"]["content"]
     assert content.startswith("Echo: hello")
 
 
 def test_echo_usage_fields(gateway):
-    _, body, _ = _post(f"{gateway}/v1/chat/completions", COMPLETION_PAYLOAD)
+    _, body, _ = _post(gateway, "/v1/chat/completions", COMPLETION_PAYLOAD)
     usage = body["usage"]
     assert "prompt_tokens" in usage
     assert "completion_tokens" in usage
@@ -168,7 +166,7 @@ def test_echo_usage_fields(gateway):
 def test_request_id_from_header(gateway):
     rid = "my-request-123"
     status, body, headers = _post(
-        f"{gateway}/v1/chat/completions",
+        gateway, "/v1/chat/completions",
         COMPLETION_PAYLOAD,
         headers={"X-Request-ID": rid},
     )
@@ -178,7 +176,7 @@ def test_request_id_from_header(gateway):
 
 
 def test_request_id_generated(gateway):
-    _, body, _ = _post(f"{gateway}/v1/chat/completions", COMPLETION_PAYLOAD)
+    _, body, _ = _post(gateway, "/v1/chat/completions", COMPLETION_PAYLOAD)
     generated_id = body["id"]
     parsed = uuid.UUID(generated_id)
     assert parsed.version == 4
@@ -187,7 +185,7 @@ def test_request_id_generated(gateway):
 def test_request_id_alt_header(gateway):
     rid = "alt-request-456"
     status, body, _ = _post(
-        f"{gateway}/v1/chat/completions",
+        gateway, "/v1/chat/completions",
         COMPLETION_PAYLOAD,
         headers={"Request-Id": rid},
     )
@@ -201,29 +199,24 @@ def test_request_id_alt_header(gateway):
 
 
 def test_invalid_json_body(gateway):
-    req = urllib.request.Request(
-        f"{gateway}/v1/chat/completions",
-        data=b"not json",
+    resp = gateway.post(
+        "/v1/chat/completions",
+        content=b"not json",
         headers={"Content-Type": "application/json"},
-        method="POST",
     )
-    try:
-        urllib.request.urlopen(req)
-        pytest.fail("Expected HTTPError")
-    except urllib.error.HTTPError as e:
-        assert e.code == 400
-        assert json.loads(e.read())["error"] == "invalid_json"
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "invalid_json"
 
 
 def test_missing_messages(gateway):
-    status, body, _ = _post(f"{gateway}/v1/chat/completions", {})
+    status, body, _ = _post(gateway, "/v1/chat/completions", {})
     assert status == 400
     assert body["error"] == "invalid_messages"
 
 
 def test_empty_messages_list(gateway):
     status, body, _ = _post(
-        f"{gateway}/v1/chat/completions",
+        gateway, "/v1/chat/completions",
         {"model": "test", "messages": []},
     )
     assert status == 400
@@ -237,17 +230,10 @@ def test_empty_messages_list(gateway):
 
 def test_echo_streaming(gateway):
     payload = {**COMPLETION_PAYLOAD, "stream": True}
-    data = json.dumps(payload).encode()
-    req = urllib.request.Request(
-        f"{gateway}/v1/chat/completions",
-        data=data,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    with urllib.request.urlopen(req) as resp:
-        assert resp.status == 200
-        assert "text/event-stream" in resp.headers.get("Content-Type", "")
-        raw = resp.read().decode()
+    resp = gateway.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 200
+    assert "text/event-stream" in resp.headers.get("content-type", "")
+    raw = resp.text
 
     lines = [line for line in raw.split("\n") if line.startswith("data:")]
     assert any(line.startswith("data: {") for line in lines)
@@ -273,7 +259,8 @@ def test_backend_success(backend_gateway):
     )
 
     status, body, headers = _post(
-        f"{backend_gateway}/v1/chat/completions", COMPLETION_PAYLOAD
+        backend_gateway, "/v1/chat/completions",
+        COMPLETION_PAYLOAD
     )
     assert status == 200
     assert "id" in body
@@ -287,7 +274,8 @@ def test_backend_5xx(backend_gateway):
     )
 
     status, body, _ = _post(
-        f"{backend_gateway}/v1/chat/completions", COMPLETION_PAYLOAD
+        backend_gateway, "/v1/chat/completions",
+        COMPLETION_PAYLOAD
     )
     assert status == 502
     assert body["error"] == "backend_error"
@@ -300,7 +288,8 @@ def test_backend_timeout(backend_gateway):
     )
 
     status, body, _ = _post(
-        f"{backend_gateway}/v1/chat/completions", COMPLETION_PAYLOAD
+        backend_gateway, "/v1/chat/completions",
+        COMPLETION_PAYLOAD
     )
     assert status == 504
     assert body["error"] == "gateway_timeout"
@@ -313,7 +302,8 @@ def test_backend_connection_error(backend_gateway):
     )
 
     status, body, _ = _post(
-        f"{backend_gateway}/v1/chat/completions", COMPLETION_PAYLOAD
+        backend_gateway, "/v1/chat/completions",
+        COMPLETION_PAYLOAD
     )
     assert status == 502
     assert body["error"] == "backend_unavailable"
@@ -325,17 +315,19 @@ def test_backend_connection_error(backend_gateway):
 
 
 def test_metrics_increments(gateway):
-    _post(f"{gateway}/v1/chat/completions", COMPLETION_PAYLOAD)
-    _post(f"{gateway}/v1/chat/completions", COMPLETION_PAYLOAD)
+    _post(gateway, "/v1/chat/completions", COMPLETION_PAYLOAD)
+    _post(gateway, "/v1/chat/completions", COMPLETION_PAYLOAD)
 
-    _, metrics_body = _get(f"{gateway}/metrics")
+    _, metrics_body = _get(gateway, "/metrics")
     assert metrics_body["request_count"] == 2
 
 
 def test_metrics_error_count(gateway):
-    _post(f"{gateway}/v1/chat/completions", {})  # missing messages → 400
+    _post(
+        gateway, "/v1/chat/completions",
+        {})  # missing messages → 400
 
-    _, metrics_body = _get(f"{gateway}/metrics")
+    _, metrics_body = _get(gateway, "/metrics")
     assert metrics_body["error_count"] == 1
 
 
@@ -344,9 +336,9 @@ def test_metrics_prompt_tokens_echo(gateway):
         "model": "test",
         "messages": [{"role": "user", "content": "hello world"}],
     }
-    _post(f"{gateway}/v1/chat/completions", payload)
+    _post(gateway, "/v1/chat/completions", payload)
 
-    _, metrics_body = _get(f"{gateway}/metrics")
+    _, metrics_body = _get(gateway, "/metrics")
     assert metrics_body["request_count"] == 1
     assert metrics_body["prompt_tokens_total"] == 2  # len("hello world".split()) == 2
 
@@ -358,7 +350,7 @@ def test_metrics_prompt_tokens_echo(gateway):
 
 def test_invalid_message_missing_role(gateway):
     status, body, _ = _post(
-        f"{gateway}/v1/chat/completions",
+        gateway, "/v1/chat/completions",
         {"messages": [{"content": "hi"}]},
     )
     assert status == 400
@@ -367,7 +359,7 @@ def test_invalid_message_missing_role(gateway):
 
 def test_invalid_message_missing_content(gateway):
     status, body, _ = _post(
-        f"{gateway}/v1/chat/completions",
+        gateway, "/v1/chat/completions",
         {"messages": [{"role": "user"}]},
     )
     assert status == 400
@@ -376,7 +368,7 @@ def test_invalid_message_missing_content(gateway):
 
 def test_invalid_message_bad_role(gateway):
     status, body, _ = _post(
-        f"{gateway}/v1/chat/completions",
+        gateway, "/v1/chat/completions",
         {"messages": [{"role": "unknown", "content": "hi"}]},
     )
     assert status == 400
@@ -385,7 +377,7 @@ def test_invalid_message_bad_role(gateway):
 
 def test_invalid_stream_type(gateway):
     status, body, _ = _post(
-        f"{gateway}/v1/chat/completions",
+        gateway, "/v1/chat/completions",
         {"messages": [{"role": "user", "content": "hi"}], "stream": "yes"},
     )
     assert status == 400
@@ -394,7 +386,7 @@ def test_invalid_stream_type(gateway):
 
 def test_invalid_max_tokens_type(gateway):
     status, body, _ = _post(
-        f"{gateway}/v1/chat/completions",
+        gateway, "/v1/chat/completions",
         {"messages": [{"role": "user", "content": "hi"}], "max_tokens": "fifty"},
     )
     assert status == 400
@@ -403,7 +395,7 @@ def test_invalid_max_tokens_type(gateway):
 
 def test_invalid_max_tokens_range(gateway):
     status, body, _ = _post(
-        f"{gateway}/v1/chat/completions",
+        gateway, "/v1/chat/completions",
         {"messages": [{"role": "user", "content": "hi"}], "max_tokens": -1},
     )
     assert status == 400
@@ -412,7 +404,7 @@ def test_invalid_max_tokens_range(gateway):
 
 def test_invalid_temperature_range(gateway):
     status, body, _ = _post(
-        f"{gateway}/v1/chat/completions",
+        gateway, "/v1/chat/completions",
         {"messages": [{"role": "user", "content": "hi"}], "temperature": 5.0},
     )
     assert status == 400
@@ -421,7 +413,7 @@ def test_invalid_temperature_range(gateway):
 
 def test_invalid_stop_type(gateway):
     status, body, _ = _post(
-        f"{gateway}/v1/chat/completions",
+        gateway, "/v1/chat/completions",
         {"messages": [{"role": "user", "content": "hi"}], "stop": 123},
     )
     assert status == 400
@@ -431,7 +423,7 @@ def test_invalid_stop_type(gateway):
 def test_model_default_omitted(gateway):
     """Omitting model should succeed."""
     status, body, _ = _post(
-        f"{gateway}/v1/chat/completions",
+        gateway, "/v1/chat/completions",
         {"messages": [{"role": "user", "content": "hi"}]},
     )
     assert status == 200
@@ -465,7 +457,7 @@ def test_full_contract_fields_forwarded(backend_gateway):
     respx.post("http://test-backend/v1/chat/completions").mock(side_effect=capture)
 
     _post(
-        f"{backend_gateway}/v1/chat/completions",
+        backend_gateway, "/v1/chat/completions",
         {
             "messages": [{"role": "user", "content": "hi"}],
             "max_tokens": 100,
@@ -505,18 +497,14 @@ def multi_backend_gateway(monkeypatch):
         monkeypatch.setattr(main.metrics, f, 0)
     monkeypatch.setattr(main.metrics, "total_latency_ms", 0.0)
 
-    server = HTTPServer(("127.0.0.1", 0), main.GatewayHandler)
-    port = server.server_address[1]
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    yield f"http://127.0.0.1:{port}"
-    server.shutdown()
+    with TestClient(main.app, raise_server_exceptions=False) as client:
+        yield client
 
 
 def test_routing_by_model_echo(multi_backend_gateway):
     """model: 'local' routes to echo backend and response has backend: 'local'."""
     status, body, _ = _post(
-        f"{multi_backend_gateway}/v1/chat/completions",
+        multi_backend_gateway, "/v1/chat/completions",
         {"model": "local", "messages": [{"role": "user", "content": "hello"}]},
     )
     assert status == 200
@@ -527,7 +515,7 @@ def test_routing_by_model_echo(multi_backend_gateway):
 def test_routing_default_fallback(multi_backend_gateway):
     """Omitting model falls back to default (echo) backend."""
     status, body, _ = _post(
-        f"{multi_backend_gateway}/v1/chat/completions",
+        multi_backend_gateway, "/v1/chat/completions",
         {"messages": [{"role": "user", "content": "hello"}]},
     )
     assert status == 200
@@ -537,7 +525,7 @@ def test_routing_default_fallback(multi_backend_gateway):
 def test_routing_unknown_model_fallback(multi_backend_gateway):
     """Unknown model name falls back to default backend."""
     status, body, _ = _post(
-        f"{multi_backend_gateway}/v1/chat/completions",
+        multi_backend_gateway, "/v1/chat/completions",
         {
             "model": "nonexistent-backend",
             "messages": [{"role": "user", "content": "hello"}],
@@ -569,7 +557,7 @@ def test_routing_by_model_remote(multi_backend_gateway):
         )
     )
     status, body, _ = _post(
-        f"{multi_backend_gateway}/v1/chat/completions",
+        multi_backend_gateway, "/v1/chat/completions",
         {
             "model": "remote-modal-llama",
             "messages": [{"role": "user", "content": "hello"}],
@@ -619,13 +607,9 @@ def test_routing_by_model_vllm(monkeypatch):
         )
     )
 
-    server = HTTPServer(("127.0.0.1", 0), main.GatewayHandler)
-    port = server.server_address[1]
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
+    with TestClient(main.app, raise_server_exceptions=False) as _client:
         status, body, _ = _post(
-            f"http://127.0.0.1:{port}/v1/chat/completions",
+            _client, "/v1/chat/completions",
             {
                 "model": "remote-modal-vllm",
                 "messages": [{"role": "user", "content": "hello"}],
@@ -633,14 +617,13 @@ def test_routing_by_model_vllm(monkeypatch):
         )
         assert status == 200
         assert body["backend"] == "remote-modal-vllm"
-    finally:
-        server.shutdown()
+    # (inline server replaced with TestClient)
 
 
 def test_backend_metadata_in_response(multi_backend_gateway):
     """Every response includes a 'backend' field."""
     status, body, _ = _post(
-        f"{multi_backend_gateway}/v1/chat/completions",
+        multi_backend_gateway, "/v1/chat/completions",
         {"messages": [{"role": "user", "content": "hi"}]},
     )
     assert status == 200
@@ -649,7 +632,7 @@ def test_backend_metadata_in_response(multi_backend_gateway):
 
 def test_get_backends_endpoint(multi_backend_gateway):
     """GET /v1/backends lists configured backends."""
-    status, body = _get(f"{multi_backend_gateway}/v1/backends")
+    status, body = _get(multi_backend_gateway, "/v1/backends")
     assert status == 200
     names = [b["name"] for b in body["backends"]]
     assert "local" in names
@@ -695,23 +678,19 @@ def auth_gateway(monkeypatch):
         monkeypatch.setattr(main.metrics, f, 0)
     monkeypatch.setattr(main.metrics, "total_latency_ms", 0.0)
 
-    server = HTTPServer(("127.0.0.1", 0), main.GatewayHandler)
-    port = server.server_address[1]
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    yield f"http://127.0.0.1:{port}"
-    server.shutdown()
+    with TestClient(main.app, raise_server_exceptions=False) as client:
+        yield client
 
 
 def test_auth_no_header_401(auth_gateway):
-    status, body, _ = _post(f"{auth_gateway}/v1/chat/completions", COMPLETION_PAYLOAD)
+    status, body, _ = _post(auth_gateway, "/v1/chat/completions", COMPLETION_PAYLOAD)
     assert status == 401
     assert body["error"] == "unauthorized"
 
 
 def test_auth_wrong_key_401(auth_gateway):
     status, body, _ = _post(
-        f"{auth_gateway}/v1/chat/completions",
+        auth_gateway, "/v1/chat/completions",
         COMPLETION_PAYLOAD,
         headers={"Authorization": "Bearer wrong-key"},
     )
@@ -721,7 +700,7 @@ def test_auth_wrong_key_401(auth_gateway):
 
 def test_auth_correct_bearer_200(auth_gateway):
     status, _, _ = _post(
-        f"{auth_gateway}/v1/chat/completions",
+        auth_gateway, "/v1/chat/completions",
         COMPLETION_PAYLOAD,
         headers={"Authorization": "Bearer test-secret-key"},
     )
@@ -730,7 +709,7 @@ def test_auth_correct_bearer_200(auth_gateway):
 
 def test_auth_api_key_scheme(auth_gateway):
     status, _, _ = _post(
-        f"{auth_gateway}/v1/chat/completions",
+        auth_gateway, "/v1/chat/completions",
         COMPLETION_PAYLOAD,
         headers={"Authorization": "Api-Key test-secret-key"},
     )
@@ -739,7 +718,7 @@ def test_auth_api_key_scheme(auth_gateway):
 
 def test_no_auth_configured(gateway):
     """When no API_KEY is set, requests succeed without Authorization header."""
-    status, _, _ = _post(f"{gateway}/v1/chat/completions", COMPLETION_PAYLOAD)
+    status, _, _ = _post(gateway, "/v1/chat/completions", COMPLETION_PAYLOAD)
     assert status == 200
 
 
@@ -765,7 +744,8 @@ def test_backend_missing_usage_normalized(backend_gateway):
         )
     )
     status, body, _ = _post(
-        f"{backend_gateway}/v1/chat/completions", COMPLETION_PAYLOAD
+        backend_gateway, "/v1/chat/completions",
+        COMPLETION_PAYLOAD
     )
     assert status == 200
     assert body["usage"]["prompt_tokens"] == 0
@@ -795,7 +775,8 @@ def test_backend_missing_model_normalized(backend_gateway):
         )
     )
     status, body, _ = _post(
-        f"{backend_gateway}/v1/chat/completions", COMPLETION_PAYLOAD
+        backend_gateway, "/v1/chat/completions",
+        COMPLETION_PAYLOAD
     )
     assert status == 200
     assert body["model"] == "unknown"
@@ -823,7 +804,8 @@ def test_backend_missing_object_normalized(backend_gateway):
         )
     )
     status, body, _ = _post(
-        f"{backend_gateway}/v1/chat/completions", COMPLETION_PAYLOAD
+        backend_gateway, "/v1/chat/completions",
+        COMPLETION_PAYLOAD
     )
     assert status == 200
     assert body["object"] == "chat.completion"
@@ -860,7 +842,8 @@ def test_backend_extra_fields_stripped(backend_gateway):
         )
     )
     status, body, _ = _post(
-        f"{backend_gateway}/v1/chat/completions", COMPLETION_PAYLOAD
+        backend_gateway, "/v1/chat/completions",
+        COMPLETION_PAYLOAD
     )
     assert status == 200
 
@@ -907,17 +890,9 @@ def test_streaming_logs_usage(backend_gateway):
     )
 
     payload = {**COMPLETION_PAYLOAD, "stream": True}
-    data = json.dumps(payload).encode()
-    req = urllib.request.Request(
-        f"{backend_gateway}/v1/chat/completions",
-        data=data,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    with urllib.request.urlopen(req) as resp:
-        resp.read()  # consume stream
+    backend_gateway.post("/v1/chat/completions", json=payload)  # consume stream
 
-    _, metrics_body = _get(f"{backend_gateway}/metrics")
+    _, metrics_body = _get(backend_gateway, "/metrics")
     assert metrics_body["prompt_tokens_total"] == 7
     assert metrics_body["completion_tokens_total"] == 3
 
@@ -929,7 +904,7 @@ def test_streaming_logs_usage(backend_gateway):
 
 def test_echo_latency_in_usage(gateway):
     """Echo response includes latency_ms in usage."""
-    _, body, _ = _post(f"{gateway}/v1/chat/completions", COMPLETION_PAYLOAD)
+    _, body, _ = _post(gateway, "/v1/chat/completions", COMPLETION_PAYLOAD)
     assert "latency_ms" in body["usage"]
     assert body["usage"]["latency_ms"] >= 0
 
@@ -955,7 +930,7 @@ def test_backend_latency_in_usage(backend_gateway):
             },
         )
     )
-    _, body, _ = _post(f"{backend_gateway}/v1/chat/completions", COMPLETION_PAYLOAD)
+    _, body, _ = _post(backend_gateway, "/v1/chat/completions", COMPLETION_PAYLOAD)
     assert "latency_ms" in body["usage"]
     assert body["usage"]["latency_ms"] >= 0
 
@@ -982,7 +957,7 @@ def test_config_backend_latency_in_usage(multi_backend_gateway):
         )
     )
     _, body, _ = _post(
-        f"{multi_backend_gateway}/v1/chat/completions",
+        multi_backend_gateway, "/v1/chat/completions",
         {
             "model": "remote-modal-llama",
             "messages": [{"role": "user", "content": "hi"}],
@@ -1023,7 +998,7 @@ def test_model_field_not_forwarded_to_backend(multi_backend_gateway):
     respx.post("http://test-backend/v1/chat/completions").mock(side_effect=capture)
 
     _post(
-        f"{multi_backend_gateway}/v1/chat/completions",
+        multi_backend_gateway, "/v1/chat/completions",
         {
             "model": "remote-modal-llama",
             "messages": [{"role": "user", "content": "hi"}],
@@ -1058,22 +1033,17 @@ def live_gateway(monkeypatch):
         monkeypatch.setattr(main.metrics, f, 0)
     monkeypatch.setattr(main.metrics, "total_latency_ms", 0.0)
 
-    server = HTTPServer(("127.0.0.1", 0), main.GatewayHandler)
-    port = server.server_address[1]
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    yield f"http://127.0.0.1:{port}"
-    server.shutdown()
+    with TestClient(main.app, raise_server_exceptions=False) as client:
+        yield client
 
 
 @pytest.mark.live
 def test_live_backends_endpoint(live_gateway):
     """GET /v1/backends lists all backends from config.yaml."""
-    status, body = _get(f"{live_gateway}/v1/backends")
+    status, body = _get(live_gateway, "/v1/backends")
     assert status == 200
     names = [b["name"] for b in body["backends"]]
     assert "local" in names
-    assert "local-llama" in names
     assert "remote-modal-llama" in names
     assert "remote-modal-vllm" in names
     assert body["default"] == "local"
@@ -1091,46 +1061,19 @@ def _assert_valid_completion(body: dict, backend_name: str) -> None:
     assert usage["latency_ms"] >= 0
 
 
-@pytest.mark.live
-def test_live_local_llama(live_gateway):
-    """Live inference against local-llama backend."""
-    try:
-        status, body, _ = _post(
-            f"{live_gateway}/v1/chat/completions",
-            {
-                "model": "local-llama",
-                "messages": [{"role": "user", "content": "Say hi"}],
-                "max_tokens": 10,
-            },
-            timeout=_live_timeout("local-llama"),
-        )
-    except urllib.error.HTTPError as e:
-        status = e.code
-        body = json.loads(e.read())
-
-    if status in (502, 504):
-        pytest.skip(f"local-llama backend not reachable (status {status})")
-
-    assert status == 200
-    _assert_valid_completion(body, "local-llama")
-
 
 @pytest.mark.live
 def test_live_remote_modal_llama(live_gateway):
     """Live inference against remote-modal-llama backend."""
-    try:
-        status, body, _ = _post(
-            f"{live_gateway}/v1/chat/completions",
-            {
-                "model": "remote-modal-llama",
-                "messages": [{"role": "user", "content": "Say hi"}],
-                "max_tokens": 10,
-            },
-            timeout=_live_timeout("remote-modal-llama"),
-        )
-    except urllib.error.HTTPError as e:
-        status = e.code
-        body = json.loads(e.read())
+    status, body, _ = _post(
+        live_gateway, "/v1/chat/completions",
+        {
+            "model": "remote-modal-llama",
+            "messages": [{"role": "user", "content": "Say hi"}],
+            "max_tokens": 10,
+        },
+        timeout=_live_timeout("remote-modal-llama"),
+    )
 
     if status in (502, 504):
         pytest.skip(f"remote-modal-llama backend not reachable (status {status})")
@@ -1142,19 +1085,15 @@ def test_live_remote_modal_llama(live_gateway):
 @pytest.mark.live
 def test_live_remote_modal_vllm(live_gateway):
     """Live inference against remote-modal-vllm backend."""
-    try:
-        status, body, _ = _post(
-            f"{live_gateway}/v1/chat/completions",
-            {
-                "model": "remote-modal-vllm",
-                "messages": [{"role": "user", "content": "Say hi"}],
-                "max_tokens": 10,
-            },
-            timeout=_live_timeout("remote-modal-vllm"),
-        )
-    except urllib.error.HTTPError as e:
-        status = e.code
-        body = json.loads(e.read())
+    status, body, _ = _post(
+        live_gateway, "/v1/chat/completions",
+        {
+            "model": "remote-modal-vllm",
+            "messages": [{"role": "user", "content": "Say hi"}],
+            "max_tokens": 10,
+        },
+        timeout=_live_timeout("remote-modal-vllm"),
+    )
 
     if status in (502, 504):
         pytest.skip(f"remote-modal-vllm backend not reachable (status {status})")
@@ -1174,7 +1113,7 @@ def test_live_backend_timeout(live_gateway, monkeypatch):
     monkeypatch.setattr(backend, "timeout", 1.0)
 
     status, body, _ = _post(
-        f"{live_gateway}/v1/chat/completions",
+        live_gateway, "/v1/chat/completions",
         {"model": "remote-modal-vllm", "messages": [{"role": "user", "content": "hi"}]},
         timeout=10.0,
     )
@@ -1205,12 +1144,8 @@ def prom_gateway(monkeypatch):
         monkeypatch.setattr(main.metrics, f, 0)
     monkeypatch.setattr(main.metrics, "total_latency_ms", 0.0)
 
-    server = HTTPServer(("127.0.0.1", 0), main.GatewayHandler)
-    port = server.server_address[1]
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    yield f"http://127.0.0.1:{port}"
-    server.shutdown()
+    with TestClient(main.app, raise_server_exceptions=False) as client:
+        yield client
 
 
 def test_prom_requests_total_increments(prom_gateway):
@@ -1225,7 +1160,8 @@ def test_prom_requests_total_increments(prom_gateway):
     }
     before = REGISTRY.get_sample_value("gateway_requests_total", labels) or 0.0
 
-    _post(prom_gateway + "/v1/chat/completions", COMPLETION_PAYLOAD)
+    _post(prom_gateway, "/v1/chat/completions",
+        COMPLETION_PAYLOAD)
 
     after = REGISTRY.get_sample_value("gateway_requests_total", labels) or 0.0
     assert after == before + 1
@@ -1243,7 +1179,7 @@ def test_prom_tokens_total_increments(prom_gateway):
     )
 
     _post(
-        prom_gateway + "/v1/chat/completions",
+        prom_gateway, "/v1/chat/completions",
         {"model": "test", "messages": [{"role": "user", "content": "hello world"}]},
     )
 
@@ -1265,7 +1201,8 @@ def test_prom_request_duration_observed(prom_gateway):
         or 0.0
     )
 
-    _post(prom_gateway + "/v1/chat/completions", COMPLETION_PAYLOAD)
+    _post(prom_gateway, "/v1/chat/completions",
+        COMPLETION_PAYLOAD)
 
     count_after = (
         REGISTRY.get_sample_value("gateway_request_duration_seconds_count", labels)
@@ -1278,7 +1215,8 @@ def test_prom_active_requests_gauge(prom_gateway):
     """gateway_active_requests gauge returns to 0 after request completes."""
     from prometheus_client import REGISTRY
 
-    _post(prom_gateway + "/v1/chat/completions", COMPLETION_PAYLOAD)
+    _post(prom_gateway, "/v1/chat/completions",
+        COMPLETION_PAYLOAD)
 
     assert (REGISTRY.get_sample_value("gateway_active_requests") or 0.0) == 0.0
 
@@ -1294,7 +1232,8 @@ def test_prom_error_counter_increments(prom_gateway):
     }
     before = REGISTRY.get_sample_value("gateway_errors_total", labels) or 0.0
 
-    _post(prom_gateway + "/v1/chat/completions", {"model": "test", "messages": []})
+    _post(prom_gateway, "/v1/chat/completions",
+        {"model": "test", "messages": []})
 
     after = REGISTRY.get_sample_value("gateway_errors_total", labels) or 0.0
     assert after == before + 1
@@ -1313,7 +1252,7 @@ def test_prom_x_technique_header_sets_label(prom_gateway):
     before = REGISTRY.get_sample_value("gateway_requests_total", labels) or 0.0
 
     _post(
-        prom_gateway + "/v1/chat/completions",
+        prom_gateway, "/v1/chat/completions",
         COMPLETION_PAYLOAD,
         headers={"X-Technique": "chunked_prefill"},
     )
@@ -1334,7 +1273,8 @@ def test_prom_missing_x_technique_defaults_to_baseline(prom_gateway):
     }
     before = REGISTRY.get_sample_value("gateway_requests_total", labels) or 0.0
 
-    _post(prom_gateway + "/v1/chat/completions", COMPLETION_PAYLOAD)
+    _post(prom_gateway, "/v1/chat/completions",
+        COMPLETION_PAYLOAD)
 
     after = REGISTRY.get_sample_value("gateway_requests_total", labels) or 0.0
     assert after == before + 1

--- a/uv.lock
+++ b/uv.lock
@@ -123,6 +123,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -202,6 +211,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
 ]
 
 [[package]]
@@ -388,10 +413,12 @@ name = "inference-gateway"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "httpx" },
     { name = "prometheus-client" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -406,10 +433,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "prometheus-client", specifier = ">=0.20" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "uvicorn", specifier = ">=0.30" },
 ]
 
 [package.metadata.requires-dev]
@@ -701,6 +730,92 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -840,6 +955,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
 name = "synchronicity"
 version = "0.12.2"
 source = { registry = "https://pypi.org/simple" }
@@ -900,6 +1028,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace `http.server.HTTPServer` (single-threaded) with FastAPI + uvicorn for fully async concurrent request handling
- Switch all `httpx.Client` calls to `httpx.AsyncClient`
- Add custom `HTTPException` handler to keep flat `{"error": "..."}` response shape
- Update `pyproject.toml` with `fastapi>=0.115` and `uvicorn>=0.30` dependencies
- Migrate all unit tests from `HTTPServer` fixtures to `FastAPI TestClient`
- Fix live tests to match current `config.yaml` backends

## Test plan

- [x] 60 unit tests passing (`uv run pytest`)
- [x] Ruff linter clean
- [x] Live tests pass against running gateway (`uv run pytest -m live -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)