### PR TITLE
feat: add Nginx load balancer with two-gateway setup (closes #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,11 +250,11 @@ Client → :8780 (Nginx LB) → :8080 / :8081 (Gateway instances) → Modal vLLM
 ```
 
 ```bash
-# Terminal 1 — gateway instance 1
-PORT=8080 GATEWAY_METRICS_PORT=9101 uv run python main.py
+# Terminal 1 — gateway instance 1 (add API_KEY=your-key to enable auth)
+PORT=8080 GATEWAY_METRICS_PORT=9101 API_KEY=test-key uv run python main.py
 
-# Terminal 2 — gateway instance 2
-PORT=8081 GATEWAY_METRICS_PORT=9102 uv run python main.py
+# Terminal 2 — gateway instance 2 (must use the same API_KEY)
+PORT=8081 GATEWAY_METRICS_PORT=9102 API_KEY=test-key uv run python main.py
 
 # Terminal 3 — Nginx load balancer (rootless, logs to /tmp)
 nginx -p /tmp -c "$(pwd)/nginx-gateway-lb.conf"
@@ -265,18 +265,30 @@ nginx -p /tmp -s stop
 
 All client traffic goes to `:8780`; Nginx round-robins requests between the two gateway instances.
 
+> **Auth note:** Nginx is auth-transparent — it passes the `Authorization` header straight through to the gateway unchanged. If `API_KEY` is set on the gateway instances, every request through the LB must include the header. If `API_KEY` is unset (omit it from the command above), no header is required.
+
 ### Load balancing test scenario
 
 Send 10 requests through the load balancer and verify they are split evenly:
 
 ```bash
-# Send 10 requests through the LB
+# Without auth (API_KEY unset on gateway instances)
 for i in $(seq 10); do
   curl -s -X POST http://127.0.0.1:8780/v1/chat/completions \
     -H 'Content-Type: application/json' \
     -d '{"model":"local","messages":[{"role":"user","content":"hi"}]}' \
     | jq -r .backend
 done
+
+# With auth (API_KEY=test-key set on gateway instances)
+for i in $(seq 10); do
+  curl -s -X POST http://127.0.0.1:8780/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: Bearer test-key' \
+    -d '{"model":"local","messages":[{"role":"user","content":"hi"}]}' \
+    | jq -r .backend
+done
+
 # Expected output: alternating "local" entries served by instance 1 and instance 2
 
 # Verify the split — each instance should show ~5 requests

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The server listens on `http://localhost:8080` by default.
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `PORT` | `8080` | Port the HTTP server listens on |
+| `PORT` | `8080` | Port the HTTP server listens on. Set to `8081` for a second instance. |
 | `API_KEY` | *(unset)* | If set, all POST requests must include `Authorization: Bearer <key>` or `Authorization: Api-Key <key>`. Leave empty to disable auth. |
-| `GATEWAY_METRICS_PORT` | `9101` | Port for the Prometheus metrics scrape endpoint |
+| `GATEWAY_METRICS_PORT` | `9101` | Port for the Prometheus metrics scrape endpoint. Set to `9102` for a second instance. |
 | `GPU_HOURLY_COST_USD` | `1.10` | Hourly GPU cost used to estimate `gateway_gpu_cost_usd_total` (A10 default) |
 | `VLLM_SERVER_PROFILE` | `default` | Server profile label attached to all Prometheus metrics (e.g. `chunked_prefill`, `baseline`) |
 
@@ -237,15 +237,79 @@ Open `tests/bruno/` in [Bruno](https://www.usebruno.com/) and select the **local
 
 ---
 
+## Nginx Load Balancer
+
+**Prerequisites:** [nginx](https://nginx.org/) (any standard build with `ngx_http_stub_status_module`)
+
+`nginx-gateway-lb.conf` (project root) distributes traffic round-robin across two gateway instances and exposes an `/nginx_status` endpoint for Prometheus.
+
+### Full stack with two gateway instances
+
+```
+Client → :8780 (Nginx LB) → :8080 / :8081 (Gateway instances) → Modal vLLM
+```
+
+```bash
+# Terminal 1 — gateway instance 1
+PORT=8080 GATEWAY_METRICS_PORT=9101 uv run python main.py
+
+# Terminal 2 — gateway instance 2
+PORT=8081 GATEWAY_METRICS_PORT=9102 uv run python main.py
+
+# Terminal 3 — Nginx load balancer (rootless, logs to /tmp)
+nginx -p /tmp -c "$(pwd)/nginx-gateway-lb.conf"
+
+# Stop Nginx when done
+nginx -p /tmp -s stop
+```
+
+All client traffic goes to `:8780`; Nginx round-robins requests between the two gateway instances.
+
+### Load balancing test scenario
+
+Send 10 requests through the load balancer and verify they are split evenly:
+
+```bash
+# Send 10 requests through the LB
+for i in $(seq 10); do
+  curl -s -X POST http://127.0.0.1:8780/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"local","messages":[{"role":"user","content":"hi"}]}' \
+    | jq -r .backend
+done
+# Expected output: alternating "local" entries served by instance 1 and instance 2
+
+# Verify the split — each instance should show ~5 requests
+curl -s http://localhost:9101/metrics | grep 'gateway_requests_total{' | head -5
+curl -s http://localhost:9102/metrics | grep 'gateway_requests_total{' | head -5
+
+# Nginx connection stats (active connections, total requests handled)
+curl -s http://localhost:8780/nginx_status
+```
+
+### Single-gateway mode
+
+To use only one gateway (skip instance 2), comment out the second `server` line in `nginx-gateway-lb.conf`:
+
+```nginx
+upstream inference_gateways {
+    server 127.0.0.1:8080;
+    # server 127.0.0.1:8081;
+}
+```
+
+---
+
 ## Monitoring Stack (Prometheus + Grafana)
 
 **Prerequisites:** [Docker](https://docs.docker.com/get-docker/) with Compose
 
-```bash
-# 1. Start the gateway first
-uv run python main.py
+The monitoring stack scrapes **both** gateway instances, plus Nginx metrics via `nginx-prometheus-exporter`.
 
-# 2. Launch Prometheus + Grafana
+```bash
+# 1. Start both gateway instances and Nginx (see above)
+
+# 2. Launch Prometheus + Grafana + Nginx exporter
 cd monitoring
 docker compose up -d
 ```
@@ -254,15 +318,18 @@ docker compose up -d
 |---|---|---|
 | Prometheus | http://localhost:9090 | — |
 | Grafana | http://localhost:3000 | admin / admin |
+| Nginx exporter | http://localhost:9113/metrics | — |
 
 Prometheus scrapes:
-- Gateway metrics on `:9101` (`job_name: gateway`)
-- Modal vLLM standard deployment over HTTPS (`job_name: vllm_standard`)
-- Modal vLLM optimized deployment over HTTPS (`job_name: vllm_optimized`)
+- `gateway` — instance 1 metrics on `:9101`
+- `gateway2` — instance 2 metrics on `:9102`
+- `nginx` — Nginx exporter on `:9113` (active connections, requests/s, upstream health)
+- `vllm_standard` — Modal vLLM standard deployment over HTTPS
+- `vllm_optimized` — Modal vLLM optimized deployment over HTTPS
+
+Check all targets are **UP**: http://localhost:9090/targets
 
 Set `VLLM_SERVER_PROFILE=default` or `VLLM_SERVER_PROFILE=optimized` in `.env` to label gateway metrics with the active deployment.
-
-Check targets are **UP**: http://localhost:9090/targets
 
 Grafana loads with a pre-provisioned Prometheus datasource and four dashboards: **gateway-proxy**, **overview**, **technique-cost**, **tinyllama-ops**.
 

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,6 +1,9 @@
 # Run from this directory:  docker compose up -d
-# Prometheus scrapes the gateway (:9101) and vLLM (:8000) on your host via host.docker.internal
-# (Linux: extra_hosts below maps host.docker.internal → host gateway).
+#
+# Services:
+#   prometheus        — scrapes gateway1 (:9101), gateway2 (:9102), nginx-exporter, vLLM Modal
+#   grafana           — dashboards at http://localhost:3000 (admin / admin)
+#   nginx-exporter    — converts Nginx stub_status → Prometheus metrics on :9113
 
 services:
   prometheus:
@@ -28,3 +31,12 @@ services:
       - ./grafana_dashboards:/var/lib/grafana/dashboards:ro
     depends_on:
       - prometheus
+
+  nginx-exporter:
+    image: nginx/nginx-prometheus-exporter:latest
+    command:
+      - -nginx.scrape-uri=http://host.docker.internal:8780/nginx_status
+    ports:
+      - "9113:9113"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,13 +1,13 @@
 # monitoring/prometheus.yml
 #
 # Scrape targets:
-#   gateway        — Prometheus metrics on GATEWAY_METRICS_PORT (default 9101), served by
-#                    the local gateway process. Docker resolves host.docker.internal → host.
-#
+#   gateway        — instance 1 on GATEWAY_METRICS_PORT 9101 (host)
+#   gateway2       — instance 2 on GATEWAY_METRICS_PORT 9102 (host)
+#   nginx          — nginx-prometheus-exporter sidecar (Docker service)
 #   vllm_standard  — Modal vLLM Gemma4 standard deployment  (server_profile=default)
 #   vllm_optimized — Modal vLLM Gemma4 optimized deployment (server_profile=optimized)
 #
-# Both vLLM targets expose /metrics directly over HTTPS on Modal.
+# Docker resolves host.docker.internal → host machine.
 # Set VLLM_SERVER_PROFILE in .env to label gateway metrics accordingly.
 
 global:
@@ -18,6 +18,16 @@ scrape_configs:
   - job_name: gateway
     static_configs:
       - targets: ["host.docker.internal:9101"]
+    metrics_path: /metrics
+
+  - job_name: gateway2
+    static_configs:
+      - targets: ["host.docker.internal:9102"]
+    metrics_path: /metrics
+
+  - job_name: nginx
+    static_configs:
+      - targets: ["nginx-exporter:9113"]
     metrics_path: /metrics
 
   - job_name: vllm_standard

--- a/nginx-gateway-lb.conf
+++ b/nginx-gateway-lb.conf
@@ -1,0 +1,54 @@
+# Inference Gateway — Nginx Load Balancer
+#
+# Listens on :8780 and distributes requests round-robin across two gateway
+# instances on :8080 and :8081.
+#
+# Start (rootless, no root required):
+#   nginx -p /tmp -c "$(pwd)/nginx-gateway-lb.conf"
+#
+# Stop:
+#   nginx -p /tmp -s stop
+#
+# Requires: nginx with ngx_http_stub_status_module (standard in most builds)
+
+worker_processes  1;
+error_log  /tmp/nginx-gateway-lb.error.log  warn;
+pid        /tmp/nginx-gateway-lb.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    access_log  /tmp/nginx-gateway-lb.access.log;
+
+    upstream inference_gateways {
+        server 127.0.0.1:8080;   # gateway instance 1
+        server 127.0.0.1:8081;   # gateway instance 2
+        # Add more lines here to scale out further
+    }
+
+    server {
+        listen 8780;
+        server_name _;
+
+        client_max_body_size 64m;
+        proxy_read_timeout   3600s;
+        proxy_send_timeout   3600s;
+
+        # Proxy all inference traffic to the gateway pool
+        location / {
+            proxy_pass         http://inference_gateways;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_buffering    off;   # required for SSE streaming
+        }
+
+        # Nginx stub_status — scraped by nginx-prometheus-exporter in Docker
+        location /nginx_status {
+            stub_status;
+        }
+    }
+}

--- a/nginx-gateway-lb.conf
+++ b/nginx-gateway-lb.conf
@@ -16,7 +16,9 @@ error_log  /tmp/nginx-gateway-lb.error.log  warn;
 pid        /tmp/nginx-gateway-lb.pid;
 
 events {
-    worker_connections  1024;
+    # macOS default ulimit is 256; set to 256 to avoid "exceed open file limit" warning.
+    # On Linux increase to 1024+ if needed (ulimit -n 1024).
+    worker_connections  256;
 }
 
 http {

--- a/tests/bruno/Nginx LB/folder.bru
+++ b/tests/bruno/Nginx LB/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: Nginx LB
+}

--- a/tests/bruno/Nginx LB/lb_chat_completion.bru
+++ b/tests/bruno/Nginx LB/lb_chat_completion.bru
@@ -1,0 +1,55 @@
+meta {
+  name: LB → Chat Completion (load balancing test)
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{lb_url}}/v1/chat/completions
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "model": "local",
+    "messages": [{"role": "user", "content": "hello via load balancer"}]
+  }
+}
+
+docs {
+  Routes a chat completion through Nginx :8780 to one of the gateway instances.
+
+  Load balancing test: run this request multiple times (or use Bruno's
+  collection runner) and compare gateway_requests_total on :9101 vs :9102 —
+  each instance should receive roughly half the requests.
+
+    curl -s http://localhost:9101/metrics | grep gateway_requests_total
+    curl -s http://localhost:9102/metrics | grep gateway_requests_total
+}
+
+tests {
+  test("status is 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response has id field", function() {
+    expect(res.body).to.have.property("id");
+  });
+
+  test("response has choices", function() {
+    expect(res.body.choices).to.be.an("array").with.length.greaterThan(0);
+  });
+
+  test("content starts with Echo:", function() {
+    expect(res.body.choices[0].message.content).to.include("Echo:");
+  });
+
+  test("response has backend field", function() {
+    expect(res.body).to.have.property("backend");
+  });
+
+  test("usage includes latency_ms", function() {
+    expect(res.body.usage).to.have.property("latency_ms");
+  });
+}

--- a/tests/bruno/Nginx LB/lb_healthz.bru
+++ b/tests/bruno/Nginx LB/lb_healthz.bru
@@ -1,0 +1,31 @@
+meta {
+  name: LB → Gateway Health Check
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{lb_url}}/healthz
+  body: none
+  auth: inherit
+}
+
+docs {
+  Verifies the full path: Client → Nginx :8780 → Gateway :8080/:8081
+  The gateway's /healthz response confirms Nginx is correctly proxying traffic.
+}
+
+tests {
+  test("status is 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("body is {status: ok}", function() {
+    expect(res.body).to.deep.equal({ status: "ok" });
+  });
+
+  test("response came through Nginx (no direct gateway port used)", function() {
+    // If this request succeeded, Nginx routed it to a gateway instance
+    expect(res.status).to.equal(200);
+  });
+}

--- a/tests/bruno/Nginx LB/nginx_status.bru
+++ b/tests/bruno/Nginx LB/nginx_status.bru
@@ -1,0 +1,50 @@
+meta {
+  name: Nginx stub_status
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{lb_url}}/nginx_status
+  body: none
+  auth: none
+}
+
+docs {
+  Nginx stub_status endpoint — scraped by nginx-prometheus-exporter in Docker.
+  Returns plain-text connection stats, not JSON.
+
+  Example response:
+    Active connections: 5
+    server accepts handled requests
+     5 5 5
+    Reading: 0 Writing: 1 Waiting: 4
+
+  Notes:
+  - accepts = handled = requests means no dropped connections (healthy)
+  - Waiting > 0 is normal: these are HTTP keep-alive connections held open
+    by Nginx after a request, waiting for potential follow-up requests.
+    They expire after Nginx's keepalive_timeout (default 65s) and drop to 0.
+  - The tests below check field names only, not values, so they remain
+    stable across multiple runs.
+}
+
+tests {
+  test("status is 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response contains Active connections", function() {
+    expect(res.body).to.include("Active connections");
+  });
+
+  test("response contains server accepts handled requests", function() {
+    expect(res.body).to.include("server accepts handled requests");
+  });
+
+  test("response contains Reading/Writing/Waiting stats", function() {
+    expect(res.body).to.include("Reading:");
+    expect(res.body).to.include("Writing:");
+    expect(res.body).to.include("Waiting:");
+  });
+}

--- a/tests/bruno/environments/local.bru
+++ b/tests/bruno/environments/local.bru
@@ -1,5 +1,6 @@
 vars {
   base_url: http://localhost:8080
   metrics_url: http://localhost:9101
+  lb_url: http://localhost:8780
   api_key: test-key
 }

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1346,3 +1346,80 @@ def test_prom_missing_x_technique_defaults_to_baseline(prom_gateway):
 
     after = REGISTRY.get_sample_value("gateway_requests_total", labels) or 0.0
     assert after == before + 1
+
+
+# ---------------------------------------------------------------------------
+# Nginx load balancer config (#14)
+# ---------------------------------------------------------------------------
+
+
+def test_nginx_config_exists():
+    """nginx-gateway-lb.conf is present in the project root."""
+    from pathlib import Path
+
+    conf = Path("nginx-gateway-lb.conf")
+    assert conf.exists(), "nginx-gateway-lb.conf not found in project root"
+
+
+def test_nginx_config_upstream_ports():
+    """nginx-gateway-lb.conf defines upstreams on :8080 and :8081."""
+    content = open("nginx-gateway-lb.conf").read()
+    assert "127.0.0.1:8080" in content, "upstream :8080 missing"
+    assert "127.0.0.1:8081" in content, "upstream :8081 missing"
+
+
+def test_nginx_config_listen_port():
+    """nginx-gateway-lb.conf listens on port 8780."""
+    content = open("nginx-gateway-lb.conf").read()
+    assert "listen 8780" in content
+
+
+def test_nginx_config_sse_buffering_off():
+    """nginx-gateway-lb.conf disables proxy buffering (required for SSE)."""
+    content = open("nginx-gateway-lb.conf").read()
+    assert "proxy_buffering" in content and "off" in content
+
+
+def test_nginx_config_stub_status():
+    """nginx-gateway-lb.conf exposes /nginx_status for Prometheus exporter."""
+    content = open("nginx-gateway-lb.conf").read()
+    assert "stub_status" in content
+    assert "/nginx_status" in content
+
+
+def test_nginx_config_rootless():
+    """nginx-gateway-lb.conf uses /tmp paths so it runs without root."""
+    content = open("nginx-gateway-lb.conf").read()
+    assert "/tmp/" in content
+
+
+def test_prometheus_config_scrapes_both_gateways():
+    """prometheus.yml defines scrape jobs for both gateway instances."""
+    import yaml
+
+    with open("monitoring/prometheus.yml") as f:
+        cfg = yaml.safe_load(f)
+    jobs = {job["job_name"] for job in cfg["scrape_configs"]}
+    assert "gateway" in jobs, "gateway job missing"
+    assert "gateway2" in jobs, "gateway2 job missing"
+
+
+def test_prometheus_config_scrapes_nginx():
+    """prometheus.yml defines a scrape job for the nginx exporter."""
+    import yaml
+
+    with open("monitoring/prometheus.yml") as f:
+        cfg = yaml.safe_load(f)
+    jobs = {job["job_name"] for job in cfg["scrape_configs"]}
+    assert "nginx" in jobs, "nginx exporter job missing"
+
+
+def test_docker_compose_nginx_exporter():
+    """monitoring/docker-compose.yml includes the nginx-prometheus-exporter service."""
+    import yaml
+
+    with open("monitoring/docker-compose.yml") as f:
+        cfg = yaml.safe_load(f)
+    assert "nginx-exporter" in cfg["services"], "nginx-exporter service missing"
+    cmd = " ".join(cfg["services"]["nginx-exporter"].get("command", []))
+    assert "nginx_status" in cmd, "nginx_status scrape URI missing from exporter command"


### PR DESCRIPTION
## Summary

- **`nginx-gateway-lb.conf`** — rootless Nginx config (logs/pid to `/tmp`); round-robin upstream across `:8080` and `:8081`; `proxy_buffering off` for SSE streaming; `/nginx_status` stub endpoint for Prometheus
- **`monitoring/docker-compose.yml`** — adds `nginx/nginx-prometheus-exporter` service on `:9113` that scrapes `host.docker.internal:8780/nginx_status`
- **`monitoring/prometheus.yml`** — adds `gateway2` job (`:9102`) and `nginx` job (exporter `:9113`)
- **`README.md`** — new Nginx LB section with full two-gateway stack instructions and load balancing test scenario

## Full stack architecture

```
Client → :8780 (Nginx LB) → :8080 / :8081 (Gateway instances) → Modal vLLM
                                ↓
                    Prometheus scrapes :9101, :9102, :9113
```

## Test plan

- [x] 74 unit tests passing (`uv run pytest`) including 9 new config-validation tests
- [x] Ruff linter clean
- Load balancing test scenario documented in README:
  - Start 2 gateway instances on `:8080`/`:8081`
  - Start Nginx: `nginx -p /tmp -c "$(pwd)/nginx-gateway-lb.conf"`
  - Send 10 requests to `:8780` — verify split via `:9101`/`:9102` Prometheus counters
  - `curl http://localhost:8780/nginx_status` shows Nginx connection stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)