### PR TITLE
docs: SUBMISSION.md, complete .env.example, and README reflection (issue #23)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,12 +5,21 @@ GATEWAY_METRICS_PORT=9101
 GPU_HOURLY_COST_USD=1.10
 # Profile label attached to Prometheus metrics: baseline | optimized | hardcore
 VLLM_SERVER_PROFILE=baseline
+# Legacy single-backend URL (overridden by config.yaml when present)
+BACKEND_URL=
 
 # --- CrewAI / Chat UI ---
 # Full gateway base URL including /v1 (defaults to Nginx LB at :8780)
 GATEWAY_OPENAI_BASE=http://127.0.0.1:8780/v1
+# Alternative alias accepted by litellm/openai SDK (same effect as GATEWAY_OPENAI_BASE)
+#OPENAI_API_BASE=http://127.0.0.1:8780/v1
 # Set to false to bypass Nginx and hit the gateway directly on :8080
 GATEWAY_USE_LOAD_BALANCER=true
+# Host/port overrides (rarely needed; defaults: gateway=127.0.0.1:8080, LB=127.0.0.1:8780)
+#GATEWAY_HOST=127.0.0.1
+#GATEWAY_PORT=8080
+#GATEWAY_LB_HOST=127.0.0.1
+#GATEWAY_LB_PORT=8780
 # Model routed by the gateway (must match a backend name in config.yaml)
 # Options: modal-gemma4-standard | modal-gemma4-optimized | modal-gemma4-hardcore
 MODEL_NAME=modal-gemma4-optimized
@@ -18,6 +27,8 @@ MODEL_NAME=modal-gemma4-optimized
 OPENAI_API_KEY=
 # Seconds to poll /v1/models before starting the crew (0 = skip)
 CREW_VLLM_WAIT_S=0
+# Polling interval in seconds when waiting for vLLM (default: 8)
+CREW_VLLM_POLL_S=8
 # Enable streaming for LLM calls (true/false)
 CREW_LLM_STREAM=true
 # Port for the Gradio Chat UI (default: 7860)
@@ -28,3 +39,5 @@ CHAT_UI_PORT=7860
 # Default "none" means zero overhead — no imports, no connections.
 OTEL_TRACES_EXPORTER=none
 OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
+# Service name reported to Jaeger / OTLP collector
+OTEL_SERVICE_NAME=inference-gateway

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 An OpenAI-compatible HTTP gateway that routes chat completion requests to multiple configurable inference backends (llama.cpp, vLLM, or any OpenAI-compatible server) or falls back to an echo response when no real backend is reachable.
 
-**Team members:** Dev Jadhav, Ingo Villow
+**Team members:** Ingo Villnow
+
+> **Reviewer?** See [SUBMISSION.md](SUBMISSION.md) for the complete step-by-step setup guide, and [submission.ipynb](submission.ipynb) / [submission.pdf](submission.pdf) for experiment analysis, SLIs/SLOs, and hardware justification.
 
 ---
 
@@ -39,10 +41,12 @@ The server listens on `http://localhost:8080` by default.
 | `PORT` | `8080` | Port the HTTP server listens on. Set to `8081` for a second instance. |
 | `API_KEY` | *(unset)* | If set, all POST requests must include `Authorization: Bearer <key>` or `Authorization: Api-Key <key>`. Leave empty to disable auth. |
 | `GATEWAY_METRICS_PORT` | `9101` | Port for the Prometheus metrics scrape endpoint. Set to `9102` for a second instance. |
-| `GPU_HOURLY_COST_USD` | `1.10` | Hourly GPU cost used to estimate `gateway_gpu_cost_usd_total` (A10 default) |
-| `VLLM_SERVER_PROFILE` | `default` | Server profile label attached to all Prometheus metrics (e.g. `chunked_prefill`, `baseline`) |
+| `GPU_HOURLY_COST_USD` | `1.10` | Hourly GPU cost used to estimate `gateway_gpu_cost_usd_total` (A10G default). |
+| `VLLM_SERVER_PROFILE` | `default` | Server profile label attached to all Prometheus metrics (e.g. `baseline`, `optimized`, `hardcore`). |
+| `BACKEND_URL` | *(unset)* | Legacy single-backend URL. Overridden by `config.yaml` when present; if both are unset the gateway runs in echo mode. |
 | `OTEL_TRACES_EXPORTER` | `none` | Set to `otlp` to enable distributed tracing. Any other value disables tracing entirely (zero overhead). |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://127.0.0.1:4317` | gRPC endpoint for the OTLP collector (e.g. Jaeger). Only used when `OTEL_TRACES_EXPORTER=otlp`. |
+| `OTEL_SERVICE_NAME` | `inference-gateway` | Service name reported to the OTLP collector / Jaeger UI. |
 
 ### Backend configuration (`config.yaml`)
 
@@ -265,12 +269,17 @@ uv run --group crew python crew.py --topic "prefix caching for RAG" --technique 
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `GATEWAY_OPENAI_BASE` | `http://127.0.0.1:8780/v1` | Full gateway URL including `/v1` |
-| `GATEWAY_USE_LOAD_BALANCER` | `true` | Set to `false` to bypass Nginx and hit `:8080` directly |
-| `MODEL_NAME` | `modal-gemma4-optimized` | Model name passed to the gateway |
-| `OPENAI_API_KEY` / `API_KEY` | `dummy` | API key forwarded to the gateway |
-| `CREW_VLLM_WAIT_S` | `0` | Seconds to poll `/v1/models` before starting (0 = skip) |
-| `CREW_LLM_STREAM` | `true` | Enable streaming for LLM calls |
+| `GATEWAY_OPENAI_BASE` | `http://127.0.0.1:8780/v1` | Full gateway URL including `/v1`. Alias: `OPENAI_API_BASE`. |
+| `GATEWAY_USE_LOAD_BALANCER` | `true` | Set to `false` to bypass Nginx and hit `:8080` directly. |
+| `GATEWAY_HOST` | `127.0.0.1` | Gateway host override (used when `GATEWAY_USE_LOAD_BALANCER=false`). |
+| `GATEWAY_PORT` | `8080` | Gateway port override (used when `GATEWAY_USE_LOAD_BALANCER=false`). |
+| `GATEWAY_LB_HOST` | `127.0.0.1` | Nginx LB host override. |
+| `GATEWAY_LB_PORT` | `8780` | Nginx LB port override. |
+| `MODEL_NAME` | `modal-gemma4-optimized` | Model name passed to the gateway (must match a backend name in `config.yaml`). |
+| `OPENAI_API_KEY` / `API_KEY` | `dummy` | API key forwarded to the gateway. |
+| `CREW_VLLM_WAIT_S` | `0` | Seconds to poll `/v1/models` before starting the crew (0 = skip). |
+| `CREW_VLLM_POLL_S` | `8` | Polling interval in seconds while waiting for vLLM to become ready. |
+| `CREW_LLM_STREAM` | `true` | Enable streaming for LLM calls. |
 
 ### Failure modes
 
@@ -534,6 +543,7 @@ cd monitoring && docker compose up -d jaeger
 ```bash
 OTEL_TRACES_EXPORTER=otlp
 OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
+OTEL_SERVICE_NAME=inference-gateway   # name shown in Jaeger UI (optional, this is the default)
 ```
 
 **3. Restart the gateway, then run a request:**
@@ -570,3 +580,13 @@ This creates a `crew.run` root span (with `llm.technique=chunked_prefill`) that 
 | Backend did not respond in time | 504 | `{"error": "gateway_timeout"}` |
 | Backend returned 5xx | 502 | `{"error": "backend_error"}` |
 | Backend unreachable | 502 | `{"error": "backend_unavailable"}` |
+
+---
+
+## Reflection
+
+**Biggest surprise:** Gemma 4 uses heterogeneous attention head dimensions (256 for local layers, 512 for global layers), which forces vLLM to fall back from FlashAttention to the Triton attention backend. This was undocumented for vLLM 0.19.0 and only surfaced at serve-time. The practical effect was lower throughput (~20–40 tok/s on A10G) than comparably sized models with uniform head dimensions. The workaround was `--async-scheduling` with tuned batch budgets (`--max-num-batched-tokens`) to prevent Triton from becoming the bottleneck.
+
+**What broke first (and which metric caught it):** The first experiment run timed out because the Modal cold-start — image pull, CUDA initialisation, and weight download — exceeded the gateway's 120 s backend timeout. The metric that caught it was `gateway_errors_total{status_code="504"}` spiking immediately in Grafana. Increasing `scaledown_window` to 15 minutes and raising `timeout` in `config.yaml` fixed the issue for all subsequent runs.
+
+**Next steps for production:** Three changes would have the most impact: (1) **FP8 KV cache on H100** — Hopper (compute capability ≥ 9.0) unlocks `--kv-cache-dtype fp8`, halving KV memory and allowing `max_model_len=32768` or far higher concurrency on the same VRAM budget. (2) **Modal autoscaling** — replacing `min_containers=max_containers=1` with a proper autoscaler that scales to zero when idle would make the cost SLO self-enforcing. (3) **Structured crew output** — adding a Pydantic output schema to the CrewAI Writer task would enforce the 120-word contract at the framework level and eliminate silent application-layer SLO violations.

--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -1,0 +1,219 @@
+# Inference Gateway — Submission
+
+**Author:** Ingo Villnow  
+**Stack:** Python gateway · Nginx LB · Modal vLLM (A10G, Gemma 4 E2B-IT) · CrewAI Researcher→Writer · Prometheus + Grafana
+
+This document gives a reviewer everything needed to clone, configure, and run the full stack from scratch.  
+For architecture details, API reference, and test instructions see [README.md](README.md).  
+For experiment analysis, SLIs/SLOs, and hardware justification see [submission.ipynb](submission.ipynb) / [submission.pdf](submission.pdf).
+
+---
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| [uv](https://docs.astral.sh/uv/) | ≥ 0.5 | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+| [Docker](https://docs.docker.com/get-docker/) | ≥ 24 | docker.com/get-docker |
+| [modal CLI](https://modal.com/docs/guide) | latest | `uv tool install modal` |
+| nginx | any (with `ngx_http_stub_status_module`) | `sudo apt install nginx` |
+| Hugging Face token | — | [hf.co/settings/tokens](https://huggingface.co/settings/tokens) (read access to `google/gemma-4-e2b-it`) |
+
+---
+
+## Step 1 — Clone & configure
+
+```bash
+git clone https://github.com/IngoTB303/inference-gateway.git
+cd inference-gateway
+
+# Install all dependency groups
+uv sync --group crew --group otel --group notebook
+
+# Create your local env file
+cp .env.example .env
+```
+
+Open `.env` and set at minimum:
+
+| Variable | What to set |
+|----------|-------------|
+| `API_KEY` | Any string (e.g. `test-key`) — required if you want auth |
+| `OPENAI_API_KEY` | Same value as `API_KEY` (forwarded by crew.py) |
+| `GPU_HOURLY_COST_USD` | Your Modal A10G rate (default: `1.10`) |
+
+---
+
+## Step 2 — Create Modal HuggingFace secret
+
+```bash
+modal secret create huggingface-secret HF_TOKEN=hf_<your_token>
+```
+
+This is required for the vLLM containers to download `google/gemma-4-e2b-it` from HuggingFace.
+
+---
+
+## Step 3 — Deploy Modal vLLM containers
+
+Deploy one or more profiles. Each runs `google/gemma-4-e2b-it` on an A10G GPU:
+
+```bash
+# Standard flags only (baseline)
+bash scripts/deploy_modal_vllm.sh standard
+
+# Chunked prefill + prefix caching (optimized)
+bash scripts/deploy_modal_vllm.sh optimized
+
+# Maximum batch budget (hardcore)
+bash scripts/deploy_modal_vllm.sh hardcore
+```
+
+After each deploy, the script prints the container URL. Paste it into `config.yaml`:
+
+```yaml
+# config.yaml
+backends:
+  - name: modal-gemma4-standard
+    type: http
+    url: https://ingo-villnow--vllm-gemma4-standard-serve.modal.run/
+    timeout: 120
+    model: gemma-4-e2b-it
+
+  - name: modal-gemma4-optimized
+    type: http
+    url: https://ingo-villnow--vllm-gemma4-optimized-serve.modal.run/
+    timeout: 120
+    model: gemma-4-e2b-it
+
+default_backend: local
+```
+
+---
+
+## Step 4 — Start the gateway
+
+```bash
+# Instance 1 (terminal 1)
+PORT=8080 GATEWAY_METRICS_PORT=9101 uv run python main.py
+
+# Optional — instance 2 for load balancing (terminal 2)
+PORT=8081 GATEWAY_METRICS_PORT=9102 uv run python main.py
+```
+
+Health check:
+
+```bash
+curl http://localhost:8080/health
+```
+
+---
+
+## Step 5 — Start Nginx load balancer
+
+```bash
+# Start (rootless, no sudo required)
+nginx -p /tmp -c "$(pwd)/nginx-gateway-lb.conf"
+
+# Stop
+nginx -p /tmp -s stop
+```
+
+Nginx listens on `:8780` and round-robins between `:8080` and `:8081`.
+
+**Quick alternative** — start both gateways + Nginx in one command:
+
+```bash
+API_KEY=test-key bash scripts/start_stack.sh
+```
+
+---
+
+## Step 6 — Start the monitoring stack
+
+```bash
+cd monitoring
+docker compose up -d
+```
+
+| Service | URL |
+|---------|-----|
+| Prometheus | http://localhost:9090 |
+| Grafana | http://localhost:3000 (admin / admin) |
+| Jaeger | http://localhost:16686 |
+
+Four dashboards are auto-provisioned: **Gateway Proxy**, **Overview**, **Technique Cost**, **TinyLlama Ops**.
+
+---
+
+## Step 7 — Run the crew agent
+
+```bash
+# Uses default topic and baseline technique
+uv run --group crew python crew.py
+
+# Specify technique and topic
+uv run --group crew python crew.py --technique optimized --topic "benefits of chunked prefill"
+```
+
+The Researcher→Writer crew makes 2 sequential LLM calls through the gateway. Output is printed to stdout; metrics are visible immediately in Grafana.
+
+---
+
+## Step 8 — Run the experiment suite
+
+```bash
+# 3 crew runs × 3 profiles (standard / optimized / hardcore)
+bash scripts/run_experiments.sh
+
+# Deploy containers first, then run
+bash scripts/run_experiments.sh --deploy
+
+# Custom subset, runs, and topic
+bash scripts/run_experiments.sh --profiles standard,optimized --runs 5 --topic "prefix caching"
+```
+
+Results are written to `data/experiments.csv`. A comparison table is printed to stdout when the suite completes.
+
+---
+
+## Step 9 — View dashboards & analyse results
+
+```bash
+# Open Grafana
+open http://localhost:3000   # or xdg-open on Linux
+
+# Analyse experiment results in the notebook
+uv sync --group notebook
+# Open submission.ipynb in VS Code (select the project venv as kernel)
+code submission.ipynb
+
+# Regenerate submission.pdf
+bash scripts/export_pdf.sh
+```
+
+Key PromQL queries:
+
+```promql
+# Request rate per technique
+rate(gateway_requests_total[1m])
+
+# p95 end-to-end latency
+histogram_quantile(0.95, rate(gateway_request_duration_seconds_bucket[5m]))
+
+# Cumulative GPU cost by technique
+increase(gateway_gpu_cost_usd_total[1h])
+```
+
+---
+
+## Reflection
+
+**Biggest surprise:** Gemma 4 uses heterogeneous attention head dimensions (256 for local layers, 512 for global layers), which forces vLLM to fall back from FlashAttention to the Triton attention backend. This was not documented for vLLM 0.19.0 and only surfaced at serve-time. The practical impact was lower throughput (~20–40 tok/s on A10G) than similar-sized models with uniform head dimensions. The workaround was `--async-scheduling` combined with tuned batch budgets to prevent the Triton backend from becoming the bottleneck.
+
+**What broke first (and which metric caught it):** The first experiment run timed out because the Modal cold-start — image pull, CUDA setup, and weight download — exceeded the gateway's 120 s backend timeout. The metric that caught it was `gateway_errors_total{status_code="504"}` spiking to 1 immediately in Grafana. Increasing `scaledown_window` to 15 minutes (so the container stays warm between runs) and raising `timeout` in `config.yaml` fixed the issue for all subsequent runs.
+
+**Next steps for production:** Three changes would have the most impact:
+1. **FP8 KV cache on H100** — moving to Hopper (compute capability ≥ 9.0) unlocks `--kv-cache-dtype fp8`, roughly halving KV memory usage and allowing `max_model_len=32768` or much higher concurrent sequences on the same VRAM budget.
+2. **Modal autoscaling** — replacing `min_containers=max_containers=1` with a proper autoscaler that scales to zero when idle and bursts to 3–5 containers under load would make the cost SLO self-enforcing without manual intervention.
+3. **Structured crew output + retry** — the Writer agent occasionally produces output slightly over the 120-word limit; adding a Pydantic output schema to the CrewAI task would enforce the contract at the framework level and eliminate silent application-layer SLO violations.


### PR DESCRIPTION
## Summary

- **`SUBMISSION.md`**: 9-step reviewer guide (prerequisites → clone → Modal secret → deploy vLLM → start gateway → start Nginx → start monitoring → run crew → run experiments + dashboards) + <300-word reflection section
- **`.env.example`**: now covers every env var used anywhere in the codebase — added `OPENAI_API_BASE`, `CREW_VLLM_POLL_S`, `OTEL_SERVICE_NAME`, `BACKEND_URL`, and commented `GATEWAY_HOST/PORT/LB_HOST/LB_PORT` overrides
- **`README.md`**: reviewer callout at top pointing to `SUBMISSION.md` and `submission.ipynb`; `BACKEND_URL` and `OTEL_SERVICE_NAME` added to main env table; `CREW_VLLM_POLL_S`, `OPENAI_API_BASE` alias, and `GATEWAY_HOST/PORT/LB_HOST/LB_PORT` added to crew env table; `OTEL_SERVICE_NAME` shown in tracing walkthrough; Reflection section added at bottom

## Audit result

```
Missing from .env.example : (none)
Missing from README        : (none)
In .env.example but unused : (none)
```

22 env vars used in code — all documented in both `.env.example` and `README.md`.

## Test plan

- [x] `uv run pytest` — 144 passed, 4 deselected
- [x] Audit script: 0 gaps in `.env.example`, 0 gaps in README

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)